### PR TITLE
Only the direct community to receive the aspect created notification for users

### DIFF
--- a/notifications.yml
+++ b/notifications.yml
@@ -207,13 +207,13 @@ recipients:
       rules:
         - rule:
             type: HUB_MEMBER
-            resource_id: <hubID>
+            resource_id: <communityID>
         - rule:
             type: CHALLENGE_MEMBER
-            resource_id: <challengeID>
+            resource_id: <communityID>
         - rule:
             type: OPPORTUNITY_MEMBER
-            resource_id: <opportunityID>
+            resource_id: <communityID>
   aspect_comment_created:
     - name: owner
       rules:

--- a/notifications.yml
+++ b/notifications.yml
@@ -196,13 +196,13 @@ recipients:
       rules:
         - rule:
             type: HUB_ADMIN
-            resource_id: <hubID>
+            resource_id: <communityID>
         - rule:
             type: CHALLENGE_ADMIN
-            resource_id: <challengeID>
+            resource_id: <communityID>
         - rule:
             type: OPPORTUNITY_ADMIN
-            resource_id: <opportunityID>
+            resource_id: <communityID>
     - name: user
       rules:
         - rule:

--- a/notifications.yml
+++ b/notifications.yml
@@ -178,14 +178,14 @@ recipients:
     - name: admin
       rules:
         - rule:
-            type: HUB_MEMBER
-            resource_id: <entityID>
+            type: HUB_ADMIN
+            resource_id: <hubID>
         - rule:
-            type: CHALLENGE_MEMBER
-            resource_id: <entityID>
+            type: CHALLENGE_ADMIN
+            resource_id: <challengeID>
         - rule:
-            type: OPPORTUNITY_MEMBER
-            resource_id: <entityID>
+            type: OPPORTUNITY_ADMIN
+            resource_id: <opportunityID>
     - name: member
       rules:
         - rule:

--- a/notifications.yml
+++ b/notifications.yml
@@ -135,14 +135,14 @@ recipients:
     - name: member
       rules:
         - rule:
+            type: HUB_MEMBER
+            resource_id: <entityID>
+        - rule:
             type: CHALLENGE_MEMBER
-            resource_id: <challengeID>
+            resource_id: <entityID>
         - rule:
             type: OPPORTUNITY_MEMBER
-            resource_id: <opportunityID>
-        - rule:
-            type: HUB_MEMBER
-            resource_id: <hubID>
+            resource_id: <entityID>
   communication_discussion_created:
     - name: admin
       rules:
@@ -155,14 +155,14 @@ recipients:
     - name: member
       rules:
         - rule:
+            type: HUB_MEMBER
+            resource_id: <entityID>
+        - rule:
             type: CHALLENGE_MEMBER
-            resource_id: <challengeID>
+            resource_id: <entityID>
         - rule:
             type: OPPORTUNITY_MEMBER
-            resource_id: <opportunityID>
-        - rule:
-            type: HUB_MEMBER
-            resource_id: <hubID>
+            resource_id: <entityID>
   community_review_submitted:
     - name: admin
       rules:
@@ -178,14 +178,14 @@ recipients:
     - name: admin
       rules:
         - rule:
-            type: HUB_ADMIN
-            resource_id: <hubID>
+            type: HUB_MEMBER
+            resource_id: <entityID>
         - rule:
-            type: CHALLENGE_ADMIN
-            resource_id: <challengeID>
+            type: CHALLENGE_MEMBER
+            resource_id: <entityID>
         - rule:
-            type: OPPORTUNITY_ADMIN
-            resource_id: <opportunityID>
+            type: OPPORTUNITY_MEMBER
+            resource_id: <entityID>
     - name: member
       rules:
         - rule:
@@ -196,24 +196,24 @@ recipients:
       rules:
         - rule:
             type: HUB_ADMIN
-            resource_id: <communityID>
+            resource_id: <hubID>
         - rule:
             type: CHALLENGE_ADMIN
-            resource_id: <communityID>
+            resource_id: <challengeID>
         - rule:
             type: OPPORTUNITY_ADMIN
-            resource_id: <communityID>
+            resource_id: <opportunityID>
     - name: user
       rules:
         - rule:
             type: HUB_MEMBER
-            resource_id: <communityID>
+            resource_id: <entityID>
         - rule:
             type: CHALLENGE_MEMBER
-            resource_id: <communityID>
+            resource_id: <entityID>
         - rule:
             type: OPPORTUNITY_MEMBER
-            resource_id: <communityID>
+            resource_id: <entityID>
   aspect_comment_created:
     - name: owner
       rules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-notifications",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "^0.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/services/domain/builders/aspect-created/aspect.created.notification.builder.ts
+++ b/src/services/domain/builders/aspect-created/aspect.created.notification.builder.ts
@@ -39,6 +39,10 @@ export class AspectCreatedNotificationBuilder implements INotificationBuilder {
       hubID: payload.hub.id,
       challengeID: payload.hub?.challenge?.id ?? '',
       opportunityID: payload.hub?.challenge?.opportunity?.id ?? '',
+      communityID:
+        payload.hub?.challenge?.opportunity?.id ??
+        payload.hub?.challenge?.id ??
+        payload.hub.id,
     };
 
     return this.notificationBuilder.build({

--- a/src/services/domain/builders/aspect-created/aspect.created.notification.builder.ts
+++ b/src/services/domain/builders/aspect-created/aspect.created.notification.builder.ts
@@ -39,7 +39,7 @@ export class AspectCreatedNotificationBuilder implements INotificationBuilder {
       hubID: payload.hub.id,
       challengeID: payload.hub?.challenge?.id ?? '',
       opportunityID: payload.hub?.challenge?.opportunity?.id ?? '',
-      communityID:
+      entityID:
         payload.hub?.challenge?.opportunity?.id ??
         payload.hub?.challenge?.id ??
         payload.hub.id,

--- a/src/services/domain/builders/communication-discussion-created/communication.discussion.created.notification.builder.ts
+++ b/src/services/domain/builders/communication-discussion-created/communication.discussion.created.notification.builder.ts
@@ -47,6 +47,10 @@ export class CommunicationDiscussionCreatedNotificationBuilder
       hubID: payload.hub.id,
       challengeID: payload.hub.challenge?.id ?? '',
       opportunityID: payload.hub.challenge?.opportunity?.id ?? '',
+      entityID:
+        payload.hub?.challenge?.opportunity?.id ??
+        payload.hub?.challenge?.id ??
+        payload.hub.id,
     };
 
     return this.notificationBuilder.build({

--- a/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
+++ b/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
@@ -43,6 +43,10 @@ export class CommunicationUpdateCreatedNotificationBuilder
       hubID: payload.hub.id,
       challengeID: payload.hub.challenge?.id ?? '',
       opportunityID: payload.hub.challenge?.opportunity?.id ?? '',
+      entityID:
+        payload.hub?.challenge?.opportunity?.id ??
+        payload.hub?.challenge?.id ??
+        payload.hub.id,
     };
 
     return this.notificationBuilder.build({

--- a/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
+++ b/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
@@ -37,10 +37,6 @@ export class CommunityNewMemberNotificationBuilder
       hubID: payload.hub.id,
       challengeID: payload.hub.challenge?.id ?? '',
       opportunityID: payload.hub.challenge?.opportunity?.id ?? '',
-      entityID:
-        payload.hub?.challenge?.opportunity?.id ??
-        payload.hub?.challenge?.id ??
-        payload.hub.id,
     };
 
     return this.notificationBuilder.build({

--- a/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
+++ b/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
@@ -37,6 +37,10 @@ export class CommunityNewMemberNotificationBuilder
       hubID: payload.hub.id,
       challengeID: payload.hub.challenge?.id ?? '',
       opportunityID: payload.hub.challenge?.opportunity?.id ?? '',
+      entityID:
+        payload.hub?.challenge?.opportunity?.id ??
+        payload.hub?.challenge?.id ??
+        payload.hub.id,
     };
 
     return this.notificationBuilder.build({


### PR DESCRIPTION
Suggested simple fix for ensuring notifications are only triggered for users that are admins / members of a specific community receive emails.

Essentially only one of the three credentials will then match as only one will be the right combination of credential type and resourceID...

NOTE: only done for aspect created notifications for now, but if this approach works then the same should be done for other notification types. 

NOTE: not yet tested but wanted to share a suggested fix.