### PR TITLE
Notification for Virtual Contributor invitation

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/notifications-lib",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@types/node": "^16.4.6",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Library for interacting with Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Library for interacting with Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,
@@ -20,7 +20,6 @@
     "lint:prod": "tsc --noEmit && cross-env NODE_ENV=production eslint src/**/*.ts{,x}",
     "lint:fix": "tsc --noEmit && eslint src/**/*.ts{,x} --fix"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/node": "^16.4.6",
     "@typescript-eslint/eslint-plugin": "^4.28.5",

--- a/lib/src/dto/index.ts
+++ b/lib/src/dto/index.ts
@@ -23,3 +23,4 @@ export * from './platform.user.removed.event.payload';
 export * from './platform.forum.discussion.comment.event.payload';
 export * from './platform.forum.discussion.created.event.payload';
 export * from './comment.reply.event.payload';
+export * from './virtual.contributor.invitation.created.event.payload';

--- a/lib/src/dto/virtual.contributor.invitation.created.event.payload.ts
+++ b/lib/src/dto/virtual.contributor.invitation.created.event.payload.ts
@@ -3,4 +3,8 @@ import { SpaceBaseEventPayload } from './space.base.event.payload';
 
 export interface VirtualContributorInvitationCreatedEventPayload extends SpaceBaseEventPayload {
   host: ContributorPayload;
+  virtualContributor: {
+    name: string;
+    url: string;
+  }
 }

--- a/lib/src/dto/virtual.contributor.invitation.created.event.payload.ts
+++ b/lib/src/dto/virtual.contributor.invitation.created.event.payload.ts
@@ -1,0 +1,6 @@
+import { ContributorPayload } from './contributor.payload';
+import { SpaceBaseEventPayload } from './space.base.event.payload';
+
+export interface VirtualContributorInvitationCreatedEventPayload extends SpaceBaseEventPayload {
+  host: ContributorPayload;
+}

--- a/lib/src/notification.event.type.ts
+++ b/lib/src/notification.event.type.ts
@@ -21,4 +21,5 @@ export enum NotificationEventType {
   PLATFORM_FORUM_DISCUSSION_COMMENT = 'platformForumDiscussionComment',
   PLATFORM_FORUM_DISCUSSION_CREATED = 'platformForumDiscussionCreated',
   COMMENT_REPLY = 'commentReply',
+  COMMUNITY_INVITATION_CREATED_VC = 'communityInvitationCreatedVC',
 }

--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -278,7 +278,7 @@ recipients:
         - rule:
             type: USER_SELF_MANAGEMENT
             resource_id: <commentOwnerID>
-  community_invitation_created_vc_host:
+  community_invitation_created_vc:
     - name: host
       rules:
         - rule:

--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -276,3 +276,15 @@ recipients:
         - rule:
             type: USER_SELF_MANAGEMENT
             resource_id: <commentOwnerID>
+  community_invitation_created_vc_host:
+    - name: host
+      rules:
+        - rule:
+            type: USER_SELF_MANAGEMENT
+            resource_id: <hostUserID>
+        - rule:
+            type: ORGANIZATION_OWNER
+            resource_id: <hostOrganizationID>
+        - rule:
+            type: ORGANIZATION_ADMIN
+            resource_id: <hostOrganizationID>

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "^0.29.4",
-        "@alkemio/notifications-lib": "^0.8.3",
+        "@alkemio/notifications-lib": "^0.8.4",
         "@nestjs/common": "^8.0.5",
         "@nestjs/config": "^1.0.1",
         "@nestjs/core": "^8.0.5",
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.3.tgz",
-      "integrity": "sha512-NTLt09X57gbSe0OOlwEKGbHcwtz/d1qVVuNvnlsv6yJJhZk+82FBPC6/KAzEaD/zclyVJQXcdg20NeHoEEc9Bw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
+      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA==",
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=8.5.5"
@@ -14670,9 +14670,9 @@
       }
     },
     "@alkemio/notifications-lib": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.3.tgz",
-      "integrity": "sha512-NTLt09X57gbSe0OOlwEKGbHcwtz/d1qVVuNvnlsv6yJJhZk+82FBPC6/KAzEaD/zclyVJQXcdg20NeHoEEc9Bw=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
+      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA=="
     },
     "@angular-devkit/core": {
       "version": "13.3.6",

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "^0.29.4",
-        "@alkemio/notifications-lib": "^0.8.4",
+        "@alkemio/notifications-lib": "^0.8.5",
         "@nestjs/common": "^8.0.5",
         "@nestjs/config": "^1.0.1",
         "@nestjs/core": "^8.0.5",
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
-      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.5.tgz",
+      "integrity": "sha512-8QnTL5NZuToWirLAqzrTCW45xLuK8OlmNZLzrJd6t/vxzHJ89b0FYQpZ/U2xLkr0JBtoqTKbN2tI7vLvYnO7XQ==",
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=8.5.5"
@@ -14670,9 +14670,9 @@
       }
     },
     "@alkemio/notifications-lib": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
-      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.5.tgz",
+      "integrity": "sha512-8QnTL5NZuToWirLAqzrTCW45xLuK8OlmNZLzrJd6t/vxzHJ89b0FYQpZ/U2xLkr0JBtoqTKbN2tI7vLvYnO7XQ=="
     },
     "@angular-devkit/core": {
       "version": "13.3.6",

--- a/service/package.json
+++ b/service/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@alkemio/client-lib": "^0.29.4",
-    "@alkemio/notifications-lib": "^0.8.3",
+    "@alkemio/notifications-lib": "^0.8.5",
     "@nestjs/common": "^8.0.5",
     "@nestjs/config": "^1.0.1",
     "@nestjs/core": "^8.0.5",

--- a/service/src/app.controller.ts
+++ b/service/src/app.controller.ts
@@ -37,6 +37,7 @@ import {
 import { NotificationService } from './services/domain/notification/notification.service';
 import { ALKEMIO_CLIENT_ADAPTER, LogContext } from './common/enums';
 import { CommunityExternalInvitationCreatedEventPayload } from '@alkemio/notifications-lib';
+import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
 
 @Controller()
 export class AppController {
@@ -75,6 +76,21 @@ export class AppController {
       context,
       this.notificationService.sendInvitationCreatedNotifications(eventPayload),
       NotificationEventType.COMMUNITY_INVITATION_CREATED
+    );
+  }
+
+  @EventPattern(NotificationEventType.COMMUNITY_INVITATION_CREATED_VC)
+  async sendVirtualContributorInvitationCreatedNotifications(
+    @Payload() eventPayload: VirtualContributorInvitationCreatedEventPayload,
+    @Ctx() context: RmqContext
+  ) {
+    this.sendNotifications(
+      eventPayload,
+      context,
+      this.notificationService.sendVirtualContributorInvitationCreatedNotifications(
+        eventPayload
+      ),
+      NotificationEventType.COMMUNITY_INVITATION_CREATED_VC
     );
   }
 

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -40,6 +40,7 @@ import { CommentReplyNotificationBuilder } from './services/domain/builders/comm
 import { CommunityExternalInvitationCreatedNotificationBuilder } from './services/domain/builders/community-external-invitation-created/community.external.invitation.created.notification.builder';
 import { AlkemioUrlGeneratorModule } from './services/application/alkemio-url-generator/alkemio.url.generator.module';
 import { PlatformGlobalRoleChangeNotificationBuilder } from './services/domain/builders/platform-global-role-change/platform.global.role.change.notification.builder';
+import { VirtualContributorInvitationCreatedNotificationBuilder } from './services/domain/builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder';
 
 @Module({
   imports: [
@@ -86,6 +87,7 @@ import { PlatformGlobalRoleChangeNotificationBuilder } from './services/domain/b
     CollaborationCalloutPublishedNotificationBuilder,
     CommentReplyNotificationBuilder,
     NotificationService,
+    VirtualContributorInvitationCreatedNotificationBuilder,
   ],
   controllers: [AppController],
 })

--- a/service/src/common/email-template-payload/index.ts
+++ b/service/src/common/email-template-payload/index.ts
@@ -21,3 +21,4 @@ export * from './platform.user.registered.email.payload';
 export * from './platform.forum.discussion.comment.email.payload';
 export * from './platform.forum.discussion.created.email.payload';
 export * from './comment.reply.email.payload';
+export * from './virtual.contributor.invitation.created.email.payload';

--- a/service/src/common/email-template-payload/virtual.contributor.invitation.created.email.payload.ts
+++ b/service/src/common/email-template-payload/virtual.contributor.invitation.created.email.payload.ts
@@ -1,0 +1,14 @@
+import { BaseJourneyEmailPayload } from './base.journey.email.payload';
+
+export interface VirtualContributorInvitationCreatedEmailPayload
+  extends BaseJourneyEmailPayload {
+  inviter: {
+    name: string;
+    firstName: string;
+    url: string;
+  };
+  virtualContributor: {
+    name: string;
+    url: string;
+  };
+}

--- a/service/src/common/enums/email.template.ts
+++ b/service/src/common/enums/email.template.ts
@@ -36,4 +36,5 @@ export enum EmailTemplate {
   PLATFORM_FORUM_DISCUSSION_CREATED = 'platform.forum.discussion.created',
   PLATFORM_FORUM_DISCUSSION_COMMENT = 'platform.forum.discussion.comment',
   COMMENT_REPLY = 'comment.reply',
+  COMMUNITY_INVITATION_CREATED_VC_HOST = 'community.invitation.created.vc.host',
 }

--- a/service/src/core/contracts/notification.recipient.template.provider.interface.ts
+++ b/service/src/core/contracts/notification.recipient.template.provider.interface.ts
@@ -37,7 +37,7 @@ export type TemplateConfig = {
   platform_user_removed?: TemplateRuleSet[];
   platform_forum_discussion_comment?: TemplateRuleSet[];
   comment_reply?: TemplateRuleSet[];
-  community_invitation_created_vc_host?: TemplateRuleSet[];
+  community_invitation_created_vc?: TemplateRuleSet[];
 };
 
 export interface INotificationRecipientTemplateProvider {

--- a/service/src/core/contracts/notification.recipient.template.provider.interface.ts
+++ b/service/src/core/contracts/notification.recipient.template.provider.interface.ts
@@ -37,6 +37,7 @@ export type TemplateConfig = {
   platform_user_removed?: TemplateRuleSet[];
   platform_forum_discussion_comment?: TemplateRuleSet[];
   comment_reply?: TemplateRuleSet[];
+  community_invitation_created_vc_host?: TemplateRuleSet[];
 };
 
 export interface INotificationRecipientTemplateProvider {

--- a/service/src/services/domain/builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationEventType } from '@alkemio/notifications-lib';
+import { INotificationBuilder } from '@core/contracts';
+import { ExternalUser, User } from '@core/models';
+import { AlkemioUrlGenerator } from '@src/services/application/alkemio-url-generator/alkemio.url.generator';
+import { NotificationBuilder, RoleConfig } from '@src/services/application';
+import { NotificationTemplateType } from '@src/types';
+import { EmailTemplate } from '@src/common/enums/email.template';
+import { UserPreferenceType } from '@alkemio/client-lib';
+import { VirtualContributorInvitationCreatedEmailPayload } from '@src/common/email-template-payload';
+import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
+
+@Injectable()
+export class VirtualContributorInvitationCreatedNotificationBuilder
+  implements INotificationBuilder
+{
+  constructor(
+    private readonly alkemioUrlGenerator: AlkemioUrlGenerator,
+    private readonly notificationBuilder: NotificationBuilder<
+      VirtualContributorInvitationCreatedEventPayload,
+      VirtualContributorInvitationCreatedEmailPayload
+    >
+  ) {}
+
+  build(
+    payload: VirtualContributorInvitationCreatedEventPayload
+  ): Promise<NotificationTemplateType[]> {
+    const roleConfig: RoleConfig[] = [
+      {
+        role: 'host',
+        emailTemplate: EmailTemplate.COMMUNITY_INVITATION_CREATED_VC_HOST,
+        preferenceType: UserPreferenceType.NotificationCommunityInvitationUser,
+      },
+    ];
+
+    const templateVariables = {
+      inviterID: payload.triggeredBy,
+      virtualContributorID: '-1',
+      spaceID: payload.space.id,
+      hostUserID: payload.host.id,
+      hostOrganizationID: payload.host.id,
+    };
+
+    return this.notificationBuilder.build({
+      payload,
+      eventUserId: payload.triggeredBy,
+      roleConfig,
+      templateType: 'community_invitation_created_vc_host',
+      templateVariables,
+      templatePayloadBuilderFn: this.createTemplatePayload.bind(this),
+    });
+  }
+
+  private createTemplatePayload(
+    eventPayload: VirtualContributorInvitationCreatedEventPayload,
+    recipient: User | ExternalUser,
+    inviter?: User
+  ): VirtualContributorInvitationCreatedEmailPayload {
+    if (!inviter) {
+      throw Error(
+        `Invitee not provided for '${NotificationEventType.COMMUNITY_INVITATION_CREATED_VC} event'`
+      );
+    }
+
+    const notificationPreferenceURL =
+      this.alkemioUrlGenerator.createUserNotificationPreferencesURL(recipient);
+
+    return {
+      emailFrom: 'info@alkem.io',
+      inviter: {
+        firstName: inviter.firstName,
+        name: inviter.profile.displayName,
+        url: inviter.profile.url,
+      },
+      recipient: {
+        firstName: recipient.firstName,
+        email: recipient.email,
+        notificationPreferences: notificationPreferenceURL,
+      },
+      space: {
+        displayName: eventPayload.space.profile.displayName,
+        type: eventPayload.space.type,
+        url: eventPayload.space.profile.url,
+      },
+      virtualContributor: {
+        name: (eventPayload as any).virtualContributor.name,
+        url: (eventPayload as any).virtualContributor.url,
+      },
+      platform: {
+        url: eventPayload.platform.url,
+      },
+    };
+  }
+}

--- a/service/src/services/domain/builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { NotificationEventType } from '@alkemio/notifications-lib';
+import {
+  NotificationEventType,
+  VirtualContributorInvitationCreatedEventPayload,
+} from '@alkemio/notifications-lib';
 import { INotificationBuilder } from '@core/contracts';
 import { ExternalUser, User } from '@core/models';
 import { AlkemioUrlGenerator } from '@src/services/application/alkemio-url-generator/alkemio.url.generator';
@@ -8,7 +11,6 @@ import { NotificationTemplateType } from '@src/types';
 import { EmailTemplate } from '@src/common/enums/email.template';
 import { UserPreferenceType } from '@alkemio/client-lib';
 import { VirtualContributorInvitationCreatedEmailPayload } from '@src/common/email-template-payload';
-import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
 
 @Injectable()
 export class VirtualContributorInvitationCreatedNotificationBuilder
@@ -35,7 +37,6 @@ export class VirtualContributorInvitationCreatedNotificationBuilder
 
     const templateVariables = {
       inviterID: payload.triggeredBy,
-      virtualContributorID: '-1',
       spaceID: payload.space.id,
       hostUserID: payload.host.id,
       hostOrganizationID: payload.host.id,
@@ -45,7 +46,7 @@ export class VirtualContributorInvitationCreatedNotificationBuilder
       payload,
       eventUserId: payload.triggeredBy,
       roleConfig,
-      templateType: 'community_invitation_created_vc_host',
+      templateType: 'community_invitation_created_vc',
       templateVariables,
       templatePayloadBuilderFn: this.createTemplatePayload.bind(this),
     });
@@ -83,8 +84,8 @@ export class VirtualContributorInvitationCreatedNotificationBuilder
         url: eventPayload.space.profile.url,
       },
       virtualContributor: {
-        name: (eventPayload as any).virtualContributor.name,
-        url: (eventPayload as any).virtualContributor.url,
+        name: eventPayload.virtualContributor.name,
+        url: eventPayload.virtualContributor.url,
       },
       platform: {
         url: eventPayload.platform.url,

--- a/service/src/services/domain/notification/notification.service.spec.ts
+++ b/service/src/services/domain/notification/notification.service.spec.ts
@@ -46,6 +46,7 @@ import { NotificationTemplateType } from '@src/types';
 import { CollaborationWhiteboardCreatedNotificationBuilder } from '../builders/collaboration-whiteboard-created/collaboration.whiteboard.created.notification.builder';
 import { CollaborationDiscussionCommentNotificationBuilder } from '../builders/collaboration-discussion-comment/collaboration.discussion.comment.notification.builder';
 import { PlatformGlobalRoleChangeNotificationBuilder } from '../builders/platform-global-role-change/platform.global.role.change.notification.builder';
+import { VirtualContributorInvitationCreatedNotificationBuilder } from '../builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder';
 
 const testData = {
   ...challengeAdminsData,
@@ -91,6 +92,7 @@ describe('NotificationService', () => {
         CollaborationCalloutPublishedNotificationBuilder,
         CommentReplyNotificationBuilder,
         PlatformGlobalRoleChangeNotificationBuilder,
+        VirtualContributorInvitationCreatedNotificationBuilder,
         MockNotificationBuilderProvider,
         MockConfigServiceProvider,
         MockAlkemioClientAdapterProvider,

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -28,6 +28,7 @@ import {
   CommunityInvitationCreatedEventPayload,
   CommentReplyEventPayload,
   PlatformGlobalRoleChangeEventPayload,
+  VirtualContributorInvitationCreatedEventPayload,
 } from '@alkemio/notifications-lib';
 import { AlkemioClientAdapter } from '@src/services/application/alkemio-client-adapter';
 import { NotificationTemplateType } from '@src/types/notification.template.type';
@@ -58,7 +59,6 @@ import { CommentReplyNotificationBuilder } from '../builders/comment-reply/comme
 import { CommunityExternalInvitationCreatedEventPayload } from '@alkemio/notifications-lib';
 import { PlatformGlobalRoleChangeNotificationBuilder } from '../builders/platform-global-role-change/platform.global.role.change.notification.builder';
 import { VirtualContributorInvitationCreatedNotificationBuilder } from '../builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder';
-import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
 
 @Injectable()
 export class NotificationService {

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -27,6 +27,7 @@ import {
   PlatformForumDiscussionCommentEventPayload,
   CommunityInvitationCreatedEventPayload,
   CommentReplyEventPayload,
+  PlatformGlobalRoleChangeEventPayload,
 } from '@alkemio/notifications-lib';
 import { AlkemioClientAdapter } from '@src/services/application/alkemio-client-adapter';
 import { NotificationTemplateType } from '@src/types/notification.template.type';
@@ -56,7 +57,8 @@ import { CollaborationDiscussionCommentNotificationBuilder } from '../builders/c
 import { CommentReplyNotificationBuilder } from '../builders/comment-reply/comment.reply.notification.builder';
 import { CommunityExternalInvitationCreatedEventPayload } from '@alkemio/notifications-lib';
 import { PlatformGlobalRoleChangeNotificationBuilder } from '../builders/platform-global-role-change/platform.global.role.change.notification.builder';
-import { PlatformGlobalRoleChangeEventPayload } from '@alkemio/notifications-lib';
+import { VirtualContributorInvitationCreatedNotificationBuilder } from '../builders/virtual-contributor-invitation-created/virtual.contributor.invitation.created.notification.builder';
+import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
 
 @Injectable()
 export class NotificationService {
@@ -87,7 +89,8 @@ export class NotificationService {
     private collaborationPostCommentNotificationBuilder: CollaborationPostCommentNotificationBuilder,
     private collaborationCalloutPublishedNotificationBuilder: CollaborationCalloutPublishedNotificationBuilder,
     private collaborationDiscussionCommentNotificationBuilder: CollaborationDiscussionCommentNotificationBuilder,
-    private commentReplyNotificationBuilder: CommentReplyNotificationBuilder
+    private commentReplyNotificationBuilder: CommentReplyNotificationBuilder,
+    private virtualContributorInvitationCreatedNotificationBuilder: VirtualContributorInvitationCreatedNotificationBuilder
   ) {}
 
   async sendNotifications(
@@ -127,6 +130,15 @@ export class NotificationService {
     return this.sendNotifications(
       payload,
       this.communityInvitationCreatedNotificationBuilder
+    );
+  }
+
+  async sendVirtualContributorInvitationCreatedNotifications(
+    payload: VirtualContributorInvitationCreatedEventPayload
+  ): Promise<PromiseSettledResult<NotificationStatus>[]> {
+    return this.sendNotifications(
+      payload,
+      this.virtualContributorInvitationCreatedNotificationBuilder
     );
   }
 

--- a/service/src/templates/community.external.invitation.created.invitee.js
+++ b/service/src/templates/community.external.invitation.created.invitee.js
@@ -11,13 +11,25 @@ module.exports = () => ({
       to: '{{recipient.email}}',
       subject: 'Invitation to join {{space.displayName}}',
       html: `{% extends "src/templates/_layouts/email-transactional.html" %}
-        {% block content %}<a href="{{inviter.profile}}">{{inviter.firstName}}</a> has invited you to join <a href="{{space.url}}">{{space.displayName}}</a> on Alkemio.
+        {% block content %}    <p><a href="{{inviter.profile}}">{{inviter.firstName}}</a> has invited you to join <a href="{{space.url}}">{{space.displayName}}</a> on Alkemio.</p><br>
           {% if welcomeMessage %}
-          <br>
+          <p>
           <pre><i>{{welcomeMessage}}</i></pre>
+</p>
           {% endif %}
-          <br>
-          <a class="action-button" href="{{space.url}}">click here to accept or decline</a><br><br>
+          <a class="action-button" href="{{space.url}}">click here to go to the (Sub)Space</a><br><br>
+<strong>How to Get Started:</strong>
+    <ol>
+        <li><strong><a style="color:#000000; text-decoration: none;" href="{{space.url}}">🔗 Click the Link:</a></strong> Simply click on the link above to open the (Sub)Space you've been invited to. It will take you directly to the heart of our collaborative platform.</li>
+        <li><strong>✏️ Create Your Account:</strong> Once there, you'll notice a prominent button inviting you to sign in to applow. Follow the steps to <b>create a new account</b>. Remember, this invitation is tied to the email address it was sent to, so use that same address during registration.</li>
+        <li><strong>✅ Verify and Accept:</strong> After verifying your account and signing in, you'll land back in the (Sub)Space. Look for the button to accept the invitation. Click it to officially become part of the Space community.</li>
+        <li><strong>🎉 You're In!</strong> Congratulations! You're now part of <a href="{{space.url}}">{{space.displayName}}</a>. Feel free to explore, connect with fellow members, and contribute to the discussions. If you ever feel lost during the process, don't worry—use the button in this email to return to the (Sub)Space you were invited to.</li>
+    </ol>
+    <p>We are looking forward to your valuable contributions!</p>
+
+    <p>Warm regards,</p>
+    <p>The Alkemio Team</p>
+    <br><br>
         {% endblock %}
         ${templates.footerBlock}`,
     },

--- a/service/src/templates/community.invitation.created.vc.host.js
+++ b/service/src/templates/community.invitation.created.vc.host.js
@@ -1,0 +1,20 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const templates = require('./alkemio.template.blocks');
+/* eslint-disable quotes */
+module.exports = () => ({
+  name: 'community-invitation-created-vc-host',
+  title: 'Invitation for Virtual Contributor to join {{space.displayName}}',
+  version: 1,
+  channels: {
+    email: {
+      from: '{{emailFrom}}',
+      to: '{{recipient.email}}',
+      subject: 'Invitation for Virtual Contributor to join {{space.displayName}}',
+      html: `{% extends "src/templates/_layouts/email-transactional.html" %}
+        {% block content %}Hi {{recipient.firstName}},<br>
+          <a href="{{inviter.url}}">{{inviter.firstName}}</a> has invited your Virtual Contributor <a href="{{virtualContributor.url}}">{{virtualContributor.name}}</a> to join <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
+        {% endblock %}
+        ${templates.footerBlock}`,
+    },
+  },
+});

--- a/service/src/templates/community.invitation.created.vc.host.js
+++ b/service/src/templates/community.invitation.created.vc.host.js
@@ -12,7 +12,7 @@ module.exports = () => ({
       subject: 'Invitation for Virtual Contributor to join {{space.displayName}}',
       html: `{% extends "src/templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br>
-          <a href="{{inviter.url}}">{{inviter.firstName}}</a> has invited your Virtual Contributor <a href="{{virtualContributor.url}}">{{virtualContributor.name}}</a> to join <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
+          <a href="{{inviter.url}}">{{inviter.name}}</a> has invited your Virtual Contributor <a href="{{virtualContributor.url}}">{{virtualContributor.name}}</a> to join <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
         {% endblock %}
         ${templates.footerBlock}`,
     },


### PR DESCRIPTION
Send email to host when a virtual contributor is invited to a communityл Payload will need a section for AccountHost from the account where the VC is provided from, with the following information: hostID
Иecipients should be:

users with USER_SELF_MANAGEMENT credential, with the hostID specified
users with ORGANIZATION_OWNER or ORGANIZATION_ADMIN credential with the hostID specified
Use the following preference: NOTIFICATION_COMMUNITY_INVITATION_USER