### PR TITLE
fixing Notification for commenting on a post looks ugly with mention …

### DIFF
--- a/service/src/templates/comment.reply.js
+++ b/service/src/templates/comment.reply.js
@@ -13,10 +13,10 @@ module.exports = () => ({
       html: `{% extends "src/templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br><br>
 
-        <b><a href={{reply.createdByUrl}}>{{reply.createdBy}}</a></b> replied to your comment on "<a style="color:#1d384a; text-decoration: none;" href={{comment.commentUrl}}>{{comment.commentOrigin}}</a>":
-        <br><br>
-        <pre><i>"{{reply.message}}"</i></pre>
-        <br><br>
+        <b>{{reply.createdBy}}</b> replied to your comment on "<a style="color:#1d384a; text-decoration: none;" href={{comment.commentUrl}}>{{comment.commentOrigin}}</a>":
+        <br>
+        <pre><i>{{reply.message}}</i></pre>
+        <br>
         <a class="action-button" href="{{comment.commentUrl}}">HAVE A LOOK!</a><br><br>
 
         {% endblock %}


### PR DESCRIPTION
…in it

### Describe the background of your pull request

issue 1267: https://github.com/alkem-io/product/issues/1267

I removed the link, so the name of the person who commented is not hyperlinked, and removed the second <br> and "" around the text of the comment itself. So it is set up in the same way as the mention notification e-mail, where it is shown correctly.



By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
