### PR TITLE
issue 1259 to change forum update notification text

### DIFF
--- a/service/src/templates/platform.forum.discussion.created.js
+++ b/service/src/templates/platform.forum.discussion.created.js
@@ -12,7 +12,7 @@ module.exports = () => ({
       subject: 'New discussion created: {{discussion.displayName}}',
       html: `{% extends "src/templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br><br>
-          <b>{{createdBy.firstName}}</b> created a new discussion in the Alkemio Forum: "<a style="color:#1d384a; text-decoration: none;" href="{{discussion.url}}">{{discussion.displayName}}</a>"
+          <b>{{createdBy.firstName}}</b> created a new post in the Alkemio Forum: "<a style="color:#1d384a; text-decoration: none;" href="{{discussion.url}}">{{discussion.displayName}}</a>"
           <br><br>
           <a class="action-button" href="{{discussion.url}}">HAVE A LOOK!</a><br><br>
         {% endblock %}


### PR DESCRIPTION
### Describe the background of your pull request

Changed the word "discussion" to "post"



By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated email notification template terminology from "discussion" to "post" for clarity in the Alkemio Forum notifications.

- **Bug Fixes**
	- No bug fixes were necessary as the changes were purely semantic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->