### PR TITLE
Remove link from community.invitation.created.invitee.js

### DIFF
--- a/service/src/templates/community.invitation.created.invitee.js
+++ b/service/src/templates/community.invitation.created.invitee.js
@@ -11,7 +11,7 @@ module.exports = () => ({
       subject: 'Invitation to join {{space.displayName}}',
       html: `{% extends "src/templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br>
-          <a href="{{inviter.profile}}">{{inviter.firstName}}</a> has invited you to join <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
+          <a href="{{inviter.profile}}">{{inviter.firstName}}</a> has invited you to join {{space.displayName}}.
           <br>
           <pre><i>{{welcomeMessage}}</i></pre>
           <br>


### PR DESCRIPTION
### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The community space name in invitation emails is now displayed as plain text instead of a clickable link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->