### PR TITLE
Fix invitations url redirects to welcome site

### DIFF
--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -86,7 +86,7 @@ hosting:
 alkemio:
   endpoint: ${ALKEMIO_SERVER_ENDPOINT}:http://localhost:3000/api/private/non-interactive/graphql
   webclient_endpoint: ${ALKEMIO_WEBCLIENT_ENDPOINT}:http://localhost:3000
-  webclient_invitations_path: ?dialog=invitations
+  webclient_invitations_path: /home?dialog=invitations
   service_account:
     username: ${SERVICE_ACCOUNT_USERNAME}:notifications@alkem.io
     password: ${SERVICE_ACCOUNT_PASSWORD}:change-me-now

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-notifications",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0",

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/service/src/services/domain/builders/community-invitation-created/community.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-invitation-created/community.invitation.created.notification.builder.ts
@@ -70,6 +70,9 @@ export class CommunityInvitationCreatedNotificationBuilder
 
     const notificationPreferenceURL =
       this.alkemioUrlGenerator.createUserNotificationPreferencesURL(recipient);
+    const invitationsURL = `${eventPayload.platform.url.replace(/\/+$/, '')}${
+      this.invitationsPath
+    }`;
 
     return {
       inviter: {
@@ -93,7 +96,7 @@ export class CommunityInvitationCreatedNotificationBuilder
       platform: {
         url: eventPayload.platform.url,
       },
-      invitationsURL: `${eventPayload.platform.url}${this.invitationsPath}`,
+      invitationsURL,
     };
   }
 }

--- a/service/src/services/domain/builders/community-platform-invitation-created/community.platform.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-platform-invitation-created/community.platform.invitation.created.notification.builder.ts
@@ -81,6 +81,9 @@ export class CommunityPlatformInvitationCreatedNotificationBuilder
     const emails = [...eventPayload.invitees]
       .map(invitedUser => invitedUser.email)
       .join(', ');
+    const invitationsURL = `${eventPayload.platform.url.replace(/\/+$/, '')}${
+      this.invitationsPath
+    }`;
 
     return {
       inviter: {
@@ -105,7 +108,7 @@ export class CommunityPlatformInvitationCreatedNotificationBuilder
       platform: {
         url: eventPayload.platform.url,
       },
-      invitationsURL: `${eventPayload.platform.url}${this.invitationsPath}`,
+      invitationsURL,
     };
   }
 }


### PR DESCRIPTION
Add `/home` to the invitation's path and remove redundant backslashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the construction of invitation URLs to prevent duplicate slashes and ensure correct routing to the invitations dialog.
- **Chores**
	- Updated configuration to specify a more explicit invitations path in the web client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->