### PR TITLE
Space type replaced by level in DTOs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "cSpell.words": [
+    "alkemio"
+  ]
 }

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/notifications-lib",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0"

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/notifications-lib",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Library for interacting with Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Library for interacting with Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/lib/src/dto/contributor.payload.ts
+++ b/lib/src/dto/contributor.payload.ts
@@ -1,4 +1,3 @@
-import { RoleSetContributorType } from "@alkemio/client-lib";
 
 export type ContributorPayload = {
   id: string;
@@ -7,5 +6,5 @@ export type ContributorPayload = {
     displayName: string;
     url: string;
   }
-  type: RoleSetContributorType
+  type: string
 };

--- a/lib/src/dto/in-app/in.app.notification.community.new.member.payload.ts
+++ b/lib/src/dto/in-app/in.app.notification.community.new.member.payload.ts
@@ -1,10 +1,9 @@
-import { RoleSetContributorType } from '@alkemio/client-lib';
 import { InAppNotificationPayloadBase } from './in.app.notification.payload.base';
 import { NotificationEventType } from '../../notification.event.type';
 
 export interface InAppNotificationCommunityNewMemberPayload extends InAppNotificationPayloadBase {
   type: NotificationEventType.COMMUNITY_NEW_MEMBER;
-  contributorType: RoleSetContributorType;
+  contributorType: string;
   newMemberID: string;
   spaceID: string;
 }

--- a/lib/src/dto/in-app/in.app.notification.contributor.mentioned.payload.ts
+++ b/lib/src/dto/in-app/in.app.notification.contributor.mentioned.payload.ts
@@ -1,11 +1,10 @@
-import { RoleSetContributorType } from "@alkemio/client-lib";
 import { InAppNotificationPayloadBase } from "./in.app.notification.payload.base";
 import { NotificationEventType } from '../../notification.event.type';
 
 export interface InAppNotificationContributorMentionedPayload extends InAppNotificationPayloadBase {
   type: NotificationEventType.COMMUNICATION_USER_MENTION;
   comment: string; // probably will be removed; can be too large; can be replaced with roomID, commentID
-  contributorType: RoleSetContributorType
+  contributorType: string
   commentOrigin: {
     displayName: string;
     url: string;

--- a/lib/src/dto/platform.user.invited.to.role.event.payload.ts
+++ b/lib/src/dto/platform.user.invited.to.role.event.payload.ts
@@ -1,11 +1,10 @@
-import { RoleName } from "@alkemio/client-lib";
 import { BaseEventPayload } from "./base.event.payload";
 import { ContributorPayload } from "./contributor.payload";
 
 export interface PlatformUserInvitedToRoleEventPayload
   extends BaseEventPayload {
     user: ContributorPayload;
-    role: RoleName;
+    role: string;
     invitees: {
       email: string;
     }[];

--- a/lib/src/dto/space.payload.ts
+++ b/lib/src/dto/space.payload.ts
@@ -1,7 +1,9 @@
+import { SpaceLevel } from "@alkemio/client-lib";
+
 export type SpacePayload = {
   id: string;
   nameID: string;
-  type: string;
+  level: SpaceLevel;
   profile: {
     displayName: string;
     url: string;

--- a/lib/src/dto/space.payload.ts
+++ b/lib/src/dto/space.payload.ts
@@ -1,9 +1,8 @@
-import { SpaceLevel } from "@alkemio/client-lib";
 
 export type SpacePayload = {
   id: string;
   nameID: string;
-  level: SpaceLevel;
+  level: string;
   profile: {
     displayName: string;
     url: string;

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0",
-        "@alkemio/notifications-lib": "0.10.3",
+        "@alkemio/notifications-lib": "0.10.4",
         "@nestjs/common": "^8.0.5",
         "@nestjs/config": "^1.0.1",
         "@nestjs/core": "^8.0.5",
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.3.tgz",
-      "integrity": "sha512-9Az+riTMPIWWcoOEhBL+vvw93jxfASC2uDBWH3V+pdyfHNYJTjwiwLUwvQzj70wcNH3Izxe01ADcldrfOr64fg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.4.tgz",
+      "integrity": "sha512-ekZhCs541k/WC//taFwrwgBhSTYCQRGFxZUS0art/uOBYLw1iLQhS3Hl0uV8/sXQPuPwy0WexNoTXB6MVwaJ4Q==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0"
@@ -14578,9 +14578,9 @@
       }
     },
     "@alkemio/notifications-lib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.3.tgz",
-      "integrity": "sha512-9Az+riTMPIWWcoOEhBL+vvw93jxfASC2uDBWH3V+pdyfHNYJTjwiwLUwvQzj70wcNH3Izxe01ADcldrfOr64fg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.4.tgz",
+      "integrity": "sha512-ekZhCs541k/WC//taFwrwgBhSTYCQRGFxZUS0art/uOBYLw1iLQhS3Hl0uV8/sXQPuPwy0WexNoTXB6MVwaJ4Q==",
       "requires": {
         "@alkemio/client-lib": "0.34.0"
       }

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0",
-        "@alkemio/notifications-lib": "0.10.2",
+        "@alkemio/notifications-lib": "0.10.3",
         "@nestjs/common": "^8.0.5",
         "@nestjs/config": "^1.0.1",
         "@nestjs/core": "^8.0.5",
@@ -158,9 +158,10 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.2.tgz",
-      "integrity": "sha512-fnJf6b3LQK4BI15pj1PpKwOFVelcZpHWF9DKV0YvQQm3rDRWQyhr9+ekCGUq6V6wHd3JqZXnMXh6r3ePz2qX0w==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.3.tgz",
+      "integrity": "sha512-9Az+riTMPIWWcoOEhBL+vvw93jxfASC2uDBWH3V+pdyfHNYJTjwiwLUwvQzj70wcNH3Izxe01ADcldrfOr64fg==",
+      "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0"
       },
@@ -14577,9 +14578,9 @@
       }
     },
     "@alkemio/notifications-lib": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.2.tgz",
-      "integrity": "sha512-fnJf6b3LQK4BI15pj1PpKwOFVelcZpHWF9DKV0YvQQm3rDRWQyhr9+ekCGUq6V6wHd3JqZXnMXh6r3ePz2qX0w==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.3.tgz",
+      "integrity": "sha512-9Az+riTMPIWWcoOEhBL+vvw93jxfASC2uDBWH3V+pdyfHNYJTjwiwLUwvQzj70wcNH3Izxe01ADcldrfOr64fg==",
       "requires": {
         "@alkemio/client-lib": "0.34.0"
       }

--- a/service/package.json
+++ b/service/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@alkemio/client-lib": "0.34.0",
-    "@alkemio/notifications-lib": "0.10.3",
+    "@alkemio/notifications-lib": "0.10.4",
     "@nestjs/common": "^8.0.5",
     "@nestjs/config": "^1.0.1",
     "@nestjs/core": "^8.0.5",

--- a/service/package.json
+++ b/service/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@alkemio/client-lib": "0.34.0",
-    "@alkemio/notifications-lib": "0.10.2",
+    "@alkemio/notifications-lib": "0.10.3",
     "@nestjs/common": "^8.0.5",
     "@nestjs/config": "^1.0.1",
     "@nestjs/core": "^8.0.5",

--- a/service/src/common/email-template-payload/base.journey.email.payload.ts
+++ b/service/src/common/email-template-payload/base.journey.email.payload.ts
@@ -5,5 +5,6 @@ export interface BaseJourneyEmailPayload extends BaseEmailPayload {
     displayName: string;
     url: string;
     level: string;
+    type?: string; // to distinguish space + subspace
   };
 }

--- a/service/src/common/email-template-payload/base.journey.email.payload.ts
+++ b/service/src/common/email-template-payload/base.journey.email.payload.ts
@@ -4,6 +4,6 @@ export interface BaseJourneyEmailPayload extends BaseEmailPayload {
   space: {
     displayName: string;
     url: string;
-    type: string;
+    level: string;
   };
 }

--- a/service/src/common/email-template-payload/space.created.email.payload.ts
+++ b/service/src/common/email-template-payload/space.created.email.payload.ts
@@ -1,11 +1,6 @@
 import { BaseJourneyEmailPayload } from './base.journey.email.payload';
 
 export interface SpaceCreatedEmailPayload extends BaseJourneyEmailPayload {
-  space: {
-    displayName: string;
-    url: string;
-    type: string;
-  };
   dateCreated: string;
   sender: {
     name: string;

--- a/service/src/services/application/alkemio-client-adapter/alkemio.client.adapter.spec.ts
+++ b/service/src/services/application/alkemio-client-adapter/alkemio.client.adapter.spec.ts
@@ -1,9 +1,9 @@
 import { AlkemioClient, PlatformFeatureFlagName } from '@alkemio/client-lib';
 import { Test } from '@nestjs/testing';
 import { AlkemioClientAdapterProvider } from './alkemio.client.adapter.module';
-import * as challengeAdminsData from '@test/data/challenge.admins.json';
-import * as opportunityAdminsData from '@test/data/opportunity.admins.json';
-import * as spaceAdminsData from '@test/data/space.admins.json';
+import * as spaceAdminsL1Data from '@test/data/space.admins.l1.json';
+import * as spaceAdminsL2Data from '@test/data/space.admins.l2.json';
+import * as spaceAdminsL0Data from '@test/data/space.admins.l0.json';
 import * as eventPayload from '@test/data/event.application.created.payload.json';
 import { AlkemioClientAdapter } from './alkemio.client.adapter';
 import {
@@ -17,9 +17,9 @@ import {
 } from '@src/common/enums';
 
 const testData = {
-  ...challengeAdminsData,
-  ...opportunityAdminsData,
-  ...spaceAdminsData,
+  ...spaceAdminsL0Data,
+  ...spaceAdminsL1Data,
+  ...spaceAdminsL2Data,
   ...eventPayload,
 };
 

--- a/service/src/services/domain/builders/collaboration-callout-published/collaboration.callout.published.notification.builder.ts
+++ b/service/src/services/domain/builders/collaboration-callout-published/collaboration.callout.published.notification.builder.ts
@@ -78,7 +78,7 @@ export class CollaborationCalloutPublishedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/collaboration-discussion-comment/collaboration.discussion.comment.notification.builder.ts
+++ b/service/src/services/domain/builders/collaboration-discussion-comment/collaboration.discussion.comment.notification.builder.ts
@@ -79,7 +79,7 @@ export class CollaborationDiscussionCommentNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/collaboration-post-comment/collaboration.post.comment.notification.builder.ts
+++ b/service/src/services/domain/builders/collaboration-post-comment/collaboration.post.comment.notification.builder.ts
@@ -79,7 +79,7 @@ export class CollaborationPostCommentNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/collaboration-post-created/collaboration.post.created.notification.builder.ts
+++ b/service/src/services/domain/builders/collaboration-post-created/collaboration.post.created.notification.builder.ts
@@ -85,7 +85,7 @@ export class CollaborationPostCreatedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/collaboration-whiteboard-created/collaboration.whiteboard.created.notification.builder.ts
+++ b/service/src/services/domain/builders/collaboration-whiteboard-created/collaboration.whiteboard.created.notification.builder.ts
@@ -85,7 +85,7 @@ export class CollaborationWhiteboardCreatedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/communication-community-message/communication.community.leads.message.notification.builder.ts
+++ b/service/src/services/domain/builders/communication-community-message/communication.community.leads.message.notification.builder.ts
@@ -81,7 +81,7 @@ export class CommunicationCommunityLeadsMessageNotificationBuilder
       message: eventPayload.message,
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
+++ b/service/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
@@ -77,7 +77,7 @@ export class CommunicationUpdateCreatedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/community-application-created/community.application.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-application-created/community.application.created.notification.builder.ts
@@ -81,7 +81,7 @@ export class CommunityApplicationCreatedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/community-application-created/community.application.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-application-created/community.application.created.notification.builder.ts
@@ -64,6 +64,9 @@ export class CommunityApplicationCreatedNotificationBuilder
       );
     }
 
+    const isLevel0Space = eventPayload.space.level === '0';
+    const spaceType = isLevel0Space ? 'space' : 'subspace';
+
     const notificationPreferenceURL =
       this.alkemioUrlGenerator.createUserNotificationPreferencesURL(recipient);
     return {
@@ -83,6 +86,7 @@ export class CommunityApplicationCreatedNotificationBuilder
         displayName: eventPayload.space.profile.displayName,
         level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
+        type: spaceType,
       },
       platform: {
         url: eventPayload.platform.url,

--- a/service/src/services/domain/builders/community-invitation-created/community.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-invitation-created/community.invitation.created.notification.builder.ts
@@ -90,7 +90,7 @@ export class CommunityInvitationCreatedNotificationBuilder
       welcomeMessage: eventPayload.welcomeMessage,
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/community-invitation-virtual-contributor-created/community.invitation.virtual.contributor.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-invitation-virtual-contributor-created/community.invitation.virtual.contributor.created.notification.builder.ts
@@ -80,7 +80,7 @@ export class CommunityInvitationVirtualContributorCreatedNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       virtualContributor: {

--- a/service/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
+++ b/service/src/services/domain/builders/community-new-member/community.new.member.notification.builder.ts
@@ -78,7 +78,7 @@ export class CommunityNewMemberNotificationBuilder
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/community-platform-invitation-created/community.platform.invitation.created.notification.builder.ts
+++ b/service/src/services/domain/builders/community-platform-invitation-created/community.platform.invitation.created.notification.builder.ts
@@ -98,7 +98,7 @@ export class CommunityPlatformInvitationCreatedNotificationBuilder
       welcomeMessage: eventPayload.welcomeMessage,
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       platform: {

--- a/service/src/services/domain/builders/space-created/space.created.notification.builder.ts
+++ b/service/src/services/domain/builders/space-created/space.created.notification.builder.ts
@@ -61,7 +61,7 @@ export class SpaceCreatedNotificationBuilder implements INotificationBuilder {
       },
       space: {
         displayName: eventPayload.space.profile.displayName,
-        type: eventPayload.space.type,
+        level: eventPayload.space.level,
         url: eventPayload.space.profile.url,
       },
       sender: eventPayload.sender,

--- a/service/src/services/domain/notification/notification.service.spec.ts
+++ b/service/src/services/domain/notification/notification.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test } from '@nestjs/testing';
 import { CommunityApplicationCreatedEventPayload } from '@alkemio/notifications-lib';
 import { ALKEMIO_CLIENT_ADAPTER, NOTIFICATIONS_PROVIDER } from '@common/enums';
-import * as challengeAdminsData from '@test/data/challenge.admins.json';
-import * as opportunityAdminsData from '@test/data/opportunity.admins.json';
-import * as spaceAdminsData from '@test/data/space.admins.json';
+import * as spaceAdminsL1Data from '@test/data/space.admins.l1.json';
+import * as spaceAdminsL2Data from '@test/data/space.admins.l2.json';
+import * as spaceAdminsL0Data from '@test/data/space.admins.l0.json';
 import * as eventPayload from '@test/data/event.application.created.payload.json';
 import * as adminUser from '@test/data/admin.user.json';
 import { INotifiedUsersProvider } from '@core/contracts';
@@ -50,9 +50,9 @@ import { CommunityInvitationVirtualContributorCreatedNotificationBuilder } from 
 import { SpaceCreatedNotificationBuilder } from '../builders/space-created/space.created.notification.builder';
 
 const testData = {
-  ...challengeAdminsData,
-  ...opportunityAdminsData,
-  ...spaceAdminsData,
+  ...spaceAdminsL0Data,
+  ...spaceAdminsL1Data,
+  ...spaceAdminsL2Data,
   ...eventPayload,
   ...adminUser,
 };
@@ -122,7 +122,7 @@ describe('NotificationService', () => {
       //toDo investigate mocking this function result based on input arguments https://stackoverflow.com/questions/41697513/can-i-mock-functions-with-specific-arguments-using-jest
       jest
         .spyOn(alkemioAdapter, 'getUniqueUsersMatchingCredentialCriteria')
-        .mockResolvedValue(testData.spaceAdmins);
+        .mockResolvedValue(testData.spaceAdminsL0);
 
       jest
         .spyOn(alkemioAdapter, 'getUser')
@@ -149,9 +149,9 @@ describe('NotificationService', () => {
 
     it('Should send 6 application notifications', async () => {
       const admins = [
-        ...testData.spaceAdmins,
-        ...testData.challengeAdmins,
-        ...testData.opportunityAdmins,
+        ...testData.spaceAdminsL0,
+        ...testData.spaceAdminsL1,
+        ...testData.spaceAdminsL2,
       ];
 
       const applicationCount = 6;

--- a/service/test/data/event.application.created.payload.json
+++ b/service/test/data/event.application.created.payload.json
@@ -9,7 +9,7 @@
       }
     },
     "space": {
-      "type": "challenge",
+      "level": "0",
       "id": "32818605-ef2f-4395-bb49-1dc2835c23de",
       "profile": {
         "displayName": "02 Zero Hunger",

--- a/service/test/data/space.admins.json
+++ b/service/test/data/space.admins.json
@@ -1,3 +1,0 @@
-{
-  "spaceAdmins": []
-}

--- a/service/test/data/space.admins.l0.json
+++ b/service/test/data/space.admins.l0.json
@@ -1,0 +1,3 @@
+{
+  "spaceAdminsL0": []
+}

--- a/service/test/data/space.admins.l1.json
+++ b/service/test/data/space.admins.l1.json
@@ -1,5 +1,5 @@
 {
-  "challengeAdmins": [
+  "spaceAdminsL1": [
     {
       "id": "d2c354a9-afad-4e4d-9969-cba1a925b302",
       "nameID": "madalynjerold",

--- a/service/test/data/space.admins.l2.json
+++ b/service/test/data/space.admins.l2.json
@@ -1,5 +1,5 @@
 {
-  "opportunityAdmins": [
+  "spaceAdminsL2": [
     {
       "id": "3f31a980-527d-41dd-94d0-e7f3412c0966",
       "nameID": "kathernkeira",


### PR DESCRIPTION
#389 

It does not look like the type was actually even used in the emails...
To go with the server PR of the same name.

Only emails that were found to be impacted are related to user applications, to both space + subspaces.

The resulting email now shows:
![image](https://github.com/user-attachments/assets/0b9e8882-3f12-467c-820e-91e5603a510a)
 and

![image](https://github.com/user-attachments/assets/6d369b6b-df73-4619-8555-d2d26cd0d008)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated various notification and payload structures to use a "level" property instead of "type" for spaces, aligning terminology across notifications and email templates.
  - Simplified certain payload interfaces by removing or renaming properties for clarity and consistency.
  - Generalized several property types from specific enums to plain strings for improved flexibility.

- **Chores**
  - Updated library and service dependency versions.
  - Added "alkemio" to the spell checker dictionary to prevent false spelling errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->