### PR TITLE
Adds sender name to email notifications

### DIFF
--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -58,7 +58,7 @@ notification_providers:
     #multi-provider strategy. Values can be fallback | no-fallback | roundrobin
     multi_provider_strategy: ${EMAIL_MULTI_PROVIDER_STRATEGY}:fallback
     from: ${EMAIL_FROM}:notifications@alkem.io
-    from_name: ${EMAIL_FROM_NAME}:Alkem.io
+    from_name: ${EMAIL_FROM_NAME}:Alkemio
     smtp:
       host: ${EMAIL_SMTP_HOST}:localhost
       port: ${EMAIL_SMTP_PORT}:1025

--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -58,6 +58,7 @@ notification_providers:
     #multi-provider strategy. Values can be fallback | no-fallback | roundrobin
     multi_provider_strategy: ${EMAIL_MULTI_PROVIDER_STRATEGY}:fallback
     from: ${EMAIL_FROM}:notifications@alkem.io
+    from_name: ${EMAIL_FROM_NAME}:Alkem.io
     smtp:
       host: ${EMAIL_SMTP_HOST}:localhost
       port: ${EMAIL_SMTP_PORT}:1025

--- a/service/src/services/domain/notification/notification.service.spec.ts
+++ b/service/src/services/domain/notification/notification.service.spec.ts
@@ -11,6 +11,7 @@ import NotifmeSdk, { NotificationStatus } from 'notifme-sdk';
 import { NotificationService } from './notification.service';
 import { CommunityApplicationCreatedNotificationBuilder } from '@src/services';
 import { NotificationRecipientsYmlAdapter } from '@src/services';
+import { ConfigService } from '@nestjs/config';
 import {
   PlatformUserRegisteredNotificationBuilder,
   CommunicationUpdateCreatedNotificationBuilder,
@@ -62,6 +63,7 @@ describe('NotificationService', () => {
   let alkemioAdapter: INotifiedUsersProvider;
   let notificationBuilder: NotificationBuilder<any, any>;
   let notifmeService: NotifmeSdk;
+  let configService: any;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -109,12 +111,26 @@ describe('NotificationService', () => {
     );
     notificationBuilder = moduleRef.get(NotificationBuilder);
     notifmeService = moduleRef.get(NOTIFICATIONS_PROVIDER);
+    configService = moduleRef.get(ConfigService);
   });
 
   beforeEach(() => {
     jest
       .spyOn(alkemioAdapter, 'areNotificationsEnabled')
       .mockResolvedValue(true);
+
+    // Mock the config service to return email configuration
+    jest.spyOn(configService, 'get').mockImplementation((key: any) => {
+      if (key === 'notification_providers') {
+        return {
+          email: {
+            from: 'test@example.com',
+            from_name: 'Test Notifications',
+          },
+        };
+      }
+      return undefined;
+    });
   });
 
   describe('Application Notifications', () => {

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -350,7 +350,15 @@ export class NotificationService {
     const mailFromName = this.configService.get(
       ConfigurationTypes.NOTIFICATION_PROVIDERS
     )?.email?.from_name;
-    notification.channels.email.from = `${mailFromName} <${mailFrom}>`;
+
+    if (!mailFrom) {
+      this.logger.error?.('Email from address not configured', LogContext.NOTIFICATIONS);
+      return { status: 'error' };
+    }
+
+    notification.channels.email.from = mailFromName
+      ? `${mailFromName} <${mailFrom}>`
+      : mailFrom;
 
     return this.notifmeService.send(notification.channels).then(
       res => {

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -344,9 +344,13 @@ export class NotificationService {
       return { status: 'error' };
     }
 
-    notification.channels.email.from = this.configService.get(
+    const mailFrom = this.configService.get(
       ConfigurationTypes.NOTIFICATION_PROVIDERS
     )?.email?.from;
+    const mailFromName = this.configService.get(
+      ConfigurationTypes.NOTIFICATION_PROVIDERS
+    )?.email?.from_name;
+    notification.channels.email.from = `${mailFromName} <${mailFrom}>`;
 
     return this.notifmeService.send(notification.channels).then(
       res => {

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -352,7 +352,10 @@ export class NotificationService {
     )?.email?.from_name;
 
     if (!mailFrom) {
-      this.logger.error?.('Email from address not configured', LogContext.NOTIFICATIONS);
+      this.logger.error?.(
+        'Email from address not configured',
+        LogContext.NOTIFICATIONS
+      );
       return { status: 'error' };
     }
 

--- a/service/src/services/domain/notification/notification.service.ts
+++ b/service/src/services/domain/notification/notification.service.ts
@@ -359,9 +359,15 @@ export class NotificationService {
       return { status: 'error' };
     }
 
-    notification.channels.email.from = mailFromName
+    const mailFromNameConfigured = mailFromName
       ? `${mailFromName} <${mailFrom}>`
       : mailFrom;
+    this.logger.verbose?.(
+      `Notification mail from ${mailFromNameConfigured}`,
+      LogContext.NOTIFICATIONS
+    );
+
+    notification.channels.email.from = mailFromNameConfigured;
 
     return this.notifmeService.send(notification.channels).then(
       res => {


### PR DESCRIPTION
Note: Doesn't work with mailslurper, tested & verified on ACC.

Ensures email notifications include a sender name, enhancing clarity and brand recognition for recipients.

Uses the configured name to format the 'From' field of outgoing emails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email notifications now display a sender name along with the sender email address for improved clarity in recipients' inboxes. The sender name can be customized via configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->