### PR TITLE
Community Updates Email template - display the actual message

### DIFF
--- a/service/src/common/email-template-payload/communication.update.created.email.payload.ts
+++ b/service/src/common/email-template-payload/communication.update.created.email.payload.ts
@@ -5,4 +5,5 @@ export interface CommunicationUpdateCreatedEmailPayload
   sender: {
     firstName: string;
   };
+  message: string;
 }

--- a/service/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
+++ b/service/src/services/domain/builders/communication-update-created/communication.update.created.notification.builder.ts
@@ -9,6 +9,7 @@ import { NotificationTemplateType } from '@src/types';
 import { CommunicationUpdateCreatedEmailPayload } from '@common/email-template-payload';
 import { NotificationEventType } from '@alkemio/notifications-lib';
 import { AlkemioUrlGenerator } from '@src/services/application/alkemio-url-generator/alkemio.url.generator';
+import { convertMarkdownToHtml } from '@src/utils/markdown-to-html.util';
 
 @Injectable()
 export class CommunicationUpdateCreatedNotificationBuilder
@@ -83,6 +84,7 @@ export class CommunicationUpdateCreatedNotificationBuilder
       platform: {
         url: eventPayload.platform.url,
       },
+      message: convertMarkdownToHtml(eventPayload.message ?? ''),
     };
   }
 }

--- a/service/src/templates/communication.update.admin.js
+++ b/service/src/templates/communication.update.admin.js
@@ -13,7 +13,7 @@ module.exports = () => ({
         {% block content %}Hi {{recipient.firstName}},<br><br>
 
           <b>{{sender.firstName}}</b> shared a new update in <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>, of which you are an admin.
-          <br><br>
+          <div>{{message | safe}}</div>
           <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a><br><br>
         {% endblock %}
 

--- a/service/src/templates/communication.update.admin.js
+++ b/service/src/templates/communication.update.admin.js
@@ -14,7 +14,10 @@ module.exports = () => ({
 
           <b>{{sender.firstName}}</b> shared a new update in <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>, of which you are an admin.
           <div>{{message | safe}}</div>
-          <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a><br><br>
+          <div>
+          <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a>
+          </div>
+          <em style="font-size: 13px;">Some content may not display fully in this email. Click above to see everything.</em>
         {% endblock %}
 
         ${templates.footerBlock}`,

--- a/service/src/templates/communication.update.member.js
+++ b/service/src/templates/communication.update.member.js
@@ -14,7 +14,10 @@ module.exports = () => ({
 
           <b>{{sender.firstName}}</b> shared a new update in <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
           <div>{{message | safe}}</div>
-          <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a><br><br>
+          <div>
+            <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a>
+          </div>
+          <em style="font-size: 13px;">Some content may not display fully in this email. Click above to see everything.</em>
         {% endblock %}
 
         ${templates.footerBlock}`,

--- a/service/src/templates/communication.update.member.js
+++ b/service/src/templates/communication.update.member.js
@@ -13,7 +13,7 @@ module.exports = () => ({
         {% block content %}Hi {{recipient.firstName}},<br><br>
 
           <b>{{sender.firstName}}</b> shared a new update in <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>.
-          <br><br>
+          <div>{{message | safe}}</div>
           <a class="action-button" href="{{space.url}}">HAVE A LOOK!</a><br><br>
         {% endblock %}
 

--- a/service/src/utils/markdown-to-html.util.ts
+++ b/service/src/utils/markdown-to-html.util.ts
@@ -1,0 +1,133 @@
+/**
+ * Simple markdown to HTML converter without external libraries
+ * Supports basic markdown syntax commonly used in messages:
+ * - Headings: # ## ###
+ * - Bold: **text** or __text__
+ * - Italic: *text* or _text_
+ * - Code: `code`
+ * - Images: ![alt text](image_url)
+ * - Links: [text](url) and <url>
+ * - Bullet Lists: - item or * item
+ * - Numbered Lists: 1. item 2. item
+ * - Line breaks: converted to <br> tags
+ * - HTML entities: decoded (&#x64;, &#32;, &amp;, etc.)
+ */
+export function convertMarkdownToHtml(markdown: string): string {
+  if (!markdown) {
+    return '';
+  }
+
+  let html = markdown;
+
+  // First, handle headings BEFORE converting line breaks
+  // Convert headings (# ## ###) - must be at start of line and followed by space
+  html = html.replace(
+    /^### (.+?)(\n|$)/gm,
+    '<h3 style="margin: 20px 0 10px 0; font-size: 18px; font-weight: bold; color: #1d384a;">$1</h3>\n'
+  );
+  html = html.replace(
+    /^## (.+?)(\n|$)/gm,
+    '<h2 style="margin: 24px 0 12px 0; font-size: 22px; font-weight: bold; color: #1d384a;">$1</h2>\n'
+  );
+  html = html.replace(
+    /^# (.+?)(\n|$)/gm,
+    '<h1 style="margin: 28px 0 16px 0; font-size: 26px; font-weight: bold; color: #1d384a;">$1</h1>\n'
+  );
+
+  // Convert bullet points (- or *) - must be at start of line
+  html = html.replace(/^[\s]*[\-\*]\s+(.+?)(\n|$)/gm, '<li>$1</li>\n');
+
+  // Convert numbered lists (1. 2. etc.) - must be at start of line
+  html = html.replace(/^[\s]*\d+\.\s+(.+?)(\n|$)/gm, '<ol-li>$1</ol-li>\n');
+
+  // Wrap consecutive <li> elements in <ul>
+  html = html.replace(
+    /(<li>.*?<\/li>(?:\n<li>.*?<\/li>)*)/gs,
+    '<ul style="margin: 16px 0; padding-left: 20px; list-style-type: disc;">$1</ul>'
+  );
+
+  // Wrap consecutive <ol-li> elements in <ol> and convert to <li>
+  html = html.replace(
+    /(<ol-li>.*?<\/ol-li>(?:\n<ol-li>.*?<\/ol-li>)*)/gs,
+    match => {
+      return (
+        '<ol style="margin: 16px 0; padding-left: 20px; list-style-type: decimal;">' +
+        match.replace(/<ol-li>/g, '<li>').replace(/<\/ol-li>/g, '</li>') +
+        '</ol>'
+      );
+    }
+  );
+
+  // Now convert line breaks to HTML breaks
+  html = html.replace(/\n/g, '<br>');
+
+  // Convert **bold** and __bold__ to <strong> first
+  html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/__(.*?)__/g, '<strong>$1</strong>');
+
+  // Then convert *italic* and _italic_ to <em>
+  html = html.replace(/\*([^*<>]+?)\*/g, '<em>$1</em>');
+  html = html.replace(/_([^_<>]+?)_/g, '<em>$1</em>');
+
+  // Convert `code` to <code>
+  html = html.replace(
+    /`(.*?)`/g,
+    '<code style="background-color: #f4f4f4; padding: 2px 4px; border-radius: 3px; font-family: monospace; font-size: 90%;">$1</code>'
+  );
+
+  // Convert ![alt](url) images to <img> tags (must be before link conversion)
+  html = html.replace(
+    /!\[([^\]]*)\]\(([^)]*)\)/g,
+    '<img src="$2" alt="$1" style="display: block; max-width: 100%; height: auto; border-radius: 4px; margin: 16px 0; border: 0; outline: none;" />'
+  );
+
+  // Convert <url> format links to <a> tags
+  html = html.replace(
+    /<(https?:\/\/[^>]+)>/g,
+    '<a href="$1" style="color:#1d384a; text-decoration: none;">$1</a>'
+  );
+
+  // Convert [text](url) links to <a href="url">text</a>
+  html = html.replace(
+    /\[([^\]]*)\]\(([^)]*)\)/g,
+    '<a href="$2" style="color:#1d384a; text-decoration: none;">$1</a>'
+  );
+
+  // Decode common HTML entities
+  html = html.replace(/&#x([0-9a-fA-F]+);/g, (match, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+  html = html.replace(/&#(\d+);/g, (match, dec) =>
+    String.fromCharCode(parseInt(dec, 10))
+  );
+  html = html.replace(/&amp;/g, '&');
+  html = html.replace(/&lt;/g, '<');
+  html = html.replace(/&gt;/g, '>');
+  html = html.replace(/&quot;/g, '"');
+
+  // Clean up multiple consecutive <br> tags
+  html = html.replace(/(<br>){3,}/g, '<br><br>');
+
+  // Clean up <br> tags around block elements
+  html = html.replace(/<br>(<h[1-6]>)/g, '$1');
+  html = html.replace(/(<\/h[1-6]>)<br>/g, '$1');
+  html = html.replace(/<br>(<ul>)/g, '$1');
+  html = html.replace(/(<\/ul>)<br>/g, '$1');
+  html = html.replace(/<br>(<ol>)/g, '$1');
+  html = html.replace(/(<\/ol>)<br>/g, '$1');
+  html = html.replace(/(<li>.*?)<br>(<\/li>)/g, '$1$2');
+  html = html.replace(/(<\/li>)<br>(<li>)/g, '$1$2');
+  html = html.replace(/<br>(<img[^>]*>)/g, '$1');
+  html = html.replace(/(<img[^>]*>)<br>/g, '$1');
+
+  // Remove div containers that wrap iframes (including any attributes)
+  html = html.replace(
+    /<div[^>]*>[\s\S]*?<iframe[\s\S]*?<\/iframe>[\s\S]*?<\/div>/gi,
+    ''
+  );
+
+  // Wrap everything in a container with max-width
+  html = `<blockquote><div style="text-align: left; max-width: 500px; margin: 0 auto; padding-left: 10px; font-family: Arial, sans-serif; line-height: 1.6; color: #333; border-left: 2px solid #ccc;">${html}</div></blockquote>`;
+
+  return html;
+}

--- a/service/test/utils/markdown-to-html.util.spec.ts
+++ b/service/test/utils/markdown-to-html.util.spec.ts
@@ -1,0 +1,97 @@
+import { convertMarkdownToHtml } from '../../src/utils/markdown-to-html.util';
+
+describe('Markdown to HTML Converter', () => {
+  it('should convert basic markdown to HTML', () => {
+    const markdown = '**Bold text** and *italic text*';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<strong>Bold text</strong> and <em>italic text</em>');
+    expect(result).toContain('max-width: 500px'); // Check for container
+  });
+
+  it('should convert images to HTML', () => {
+    const markdown = 'Check out ![My Image](https://example.com/image.jpg)';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<img src="https://example.com/image.jpg" alt="My Image"');
+    expect(result).toContain('display: block');
+    expect(result).toContain('max-width: 100%');
+  });
+
+  it('should handle images and links together', () => {
+    const markdown = '![Screenshot](https://example.com/screen.png) and [link](https://example.com)';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<img src="https://example.com/screen.png"');
+    expect(result).toContain('alt="Screenshot"');
+    expect(result).toContain('<a href="https://example.com"');
+  });
+
+  it('should convert links to HTML', () => {
+    const markdown = 'Check out [this link](https://example.com)';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('Check out <a href="https://example.com" style="color:#1d384a; text-decoration: none;">this link</a>');
+  });
+
+  it('should convert code blocks', () => {
+    const markdown = 'Use `console.log()` for debugging';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('Use <code style="background-color: #f4f4f4; padding: 2px 4px; border-radius: 3px; font-family: monospace; font-size: 90%;">console.log()</code> for debugging');
+  });
+
+  it('should convert line breaks', () => {
+    const markdown = 'Line 1\nLine 2';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('Line 1<br>Line 2');
+  });
+
+  it('should handle headings', () => {
+    const markdown = '# Heading 1\n## Heading 2';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<h1 style="margin: 28px 0 16px 0; font-size: 26px; font-weight: bold; color: #1d384a;">Heading 1</h1>');
+    expect(result).toContain('<h2 style="margin: 24px 0 12px 0; font-size: 22px; font-weight: bold; color: #1d384a;">Heading 2</h2>');
+  });
+
+  it('should handle bullet points', () => {
+    const markdown = '- Item 1\n- Item 2';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<ul style="margin: 16px 0; padding-left: 20px; list-style-type: disc;">');
+    expect(result).toContain('<li>Item 1</li><li>Item 2</li>');
+  });
+
+  it('should handle numbered lists', () => {
+    const markdown = '1. First item\n2. Second item';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('<ol style="margin: 16px 0; padding-left: 20px; list-style-type: decimal;">');
+    expect(result).toContain('<li>First item</li><li>Second item</li>');
+  });
+
+  it('should handle plain URL links', () => {
+    const markdown = 'Visit <https://example.com> for more info';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('Visit <a href="https://example.com" style="color:#1d384a; text-decoration: none;">https://example.com</a> for more info');
+  });
+
+  it('should decode HTML entities', () => {
+    const markdown = 'an&#x64; test &#x20; here';
+    const result = convertMarkdownToHtml(markdown);
+    expect(result).toContain('and test   here');
+  });
+
+  it('should handle empty or null input', () => {
+    expect(convertMarkdownToHtml('')).toBe('');
+    expect(convertMarkdownToHtml(null as any)).toBe('');
+    expect(convertMarkdownToHtml(undefined as any)).toBe('');
+  });
+
+  it('should handle complex markdown', () => {
+    const markdown = '# Important Update\n\nHello **team**!\n\nPlease check [our docs](https://docs.example.com) for:\n\n1. New features\n2. Bug fixes\n\nAlso visit <https://github.com/example>\n\nHere is a screenshot: ![UI Screenshot](https://example.com/ui.png)\n\nUse `npm install` to update.';
+    const result = convertMarkdownToHtml(markdown);
+
+    expect(result).toContain('<h1 style="margin: 28px 0 16px 0; font-size: 26px; font-weight: bold; color: #1d384a;">Important Update</h1>');
+    expect(result).toContain('<strong>team</strong>');
+    expect(result).toContain('<a href="https://docs.example.com"');
+    expect(result).toContain('<ol style="margin: 16px 0; padding-left: 20px; list-style-type: decimal;">');
+    expect(result).toContain('<a href="https://github.com/example"');
+    expect(result).toContain('<img src="https://example.com/ui.png"');
+    expect(result).toContain('alt="UI Screenshot"');
+    expect(result).toContain('<code style="background-color: #f4f4f4');
+  });
+});


### PR DESCRIPTION
On Community update triggered by Lead/Admin, the email templates now include the actual message.
Custom parser MD to HTML was introduced (with AI). It has some custom logic to remove iframes (and our wrapper over them). Plus some custom styling. 

Depends on the following PR: https://github.com/alkem-io/server/pull/5281