### PR TITLE
Remove redundant blockquote in md to html parser

### DIFF
--- a/service/src/utils/markdown-to-html.util.ts
+++ b/service/src/utils/markdown-to-html.util.ts
@@ -127,7 +127,7 @@ export function convertMarkdownToHtml(markdown: string): string {
   );
 
   // Wrap everything in a container with max-width
-  html = `<blockquote><div style="text-align: left; max-width: 500px; margin: 0 auto; padding-left: 10px; font-family: Arial, sans-serif; line-height: 1.6; color: #333; border-left: 2px solid #ccc;">${html}</div></blockquote>`;
+  html = `<div style="text-align: left; max-width: 500px; margin: 0 auto; padding-left: 10px; font-family: Arial, sans-serif; line-height: 1.6; color: #333; border-left: 2px solid #ccc;">${html}</div>`;
 
   return html;
 }


### PR DESCRIPTION
simple style fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the outer blockquote styling from HTML output generated from markdown, while retaining all other container styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->