### PR TITLE
Fix the wording of contributor type in join email 

### DIFF
--- a/service/src/services/notification/notification.email.payload.builder.service.ts
+++ b/service/src/services/notification/notification.email.payload.builder.service.ts
@@ -207,8 +207,9 @@ export class NotificationEmailPayloadBuilderService {
   ): CommunityNewMemberEmailPayload {
     const newMember = eventPayload.contributor;
     const typeName =
-      newMember.type === RoleSetContributorType.Virtual
-        ? 'virtual contributor'
+      newMember.type.toLowerCase() ===
+      RoleSetContributorType.Virtual.toLowerCase()
+        ? 'Virtual Contributor'
         : newMember.type;
 
     return {
@@ -227,8 +228,9 @@ export class NotificationEmailPayloadBuilderService {
   ): CommunityNewMemberEmailPayload {
     const newMember = eventPayload.contributor;
     const typeName =
-      newMember.type === RoleSetContributorType.Virtual
-        ? 'virtual contributor'
+      newMember.type.toLowerCase() ===
+      RoleSetContributorType.Virtual.toLowerCase()
+        ? 'Virtual Contributor'
         : newMember.type;
 
     return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Email notifications now display "Virtual Contributor" with proper capitalization in community-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->