### PR TITLE
Application insted of invitation for application declined email

### DIFF
--- a/service/src/email-templates/user.space.community.application.declined.js
+++ b/service/src/email-templates/user.space.community.application.declined.js
@@ -3,15 +3,15 @@ const templates = require('./alkemio.template.blocks');
 /* eslint-disable quotes */
 module.exports = () => ({
   name: 'user.space.community.application.declined',
-  title: '[{{space.displayName}}] {{decliner.name}} declined your invitation',
+  title: '[{{space.displayName}}] {{decliner.name}} declined your application',
   version: 1,
   channels: {
     email: {
       to: '{{recipient.email}}',
-      subject: '{{decliner.name}} declined your invitation for {{space.displayName}}',
+      subject: '{{decliner.name}} declined your application for {{space.displayName}}',
       html: `{% extends "src/email-templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br>
-          <a href="{{decliner.profile}}">{{decliner.firstName}}</a> declined your invitation for {{space.displayName}}.
+          <a href="{{decliner.profile}}">{{decliner.firstName}}</a> declined your application for {{space.displayName}}.
           <br><br>
           <a class="action-button" href="{{spaceURL}}">Have a look</a><br><br>
         {% endblock %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Email notifications for declined applications now use "application" instead of "invitation" in the email title, subject line, and body content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->