### PR TITLE
Implement configurable email blacklist for notifications service

### DIFF
--- a/specs/001-create-configurable-black/checklists/requirements.md
+++ b/specs/001-create-configurable-black/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Configurable Email Blacklist for Notifications
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2025-11-18  
+**Feature**: `specs/001-create-configurable-black/spec.md`
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous
+- [ ] Success criteria are measurable
+- [ ] Success criteria are technology-agnostic (no implementation details)
+- [ ] All acceptance scenarios are defined
+- [ ] Edge cases are identified
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [ ] All functional requirements have clear acceptance criteria
+- [ ] User scenarios cover primary flows
+- [ ] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/001-create-configurable-black/plan.md
+++ b/specs/001-create-configurable-black/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Configurable Email Blacklist for Notifications
+
+**Branch**: `001-create-configurable-black` | **Date**: 2025-11-18 | **Spec**: `specs/001-create-configurable-black/spec.md`
+**Input**: Feature specification from `/specs/001-create-configurable-black/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add a configurable, global blacklist of exact email addresses that must never receive notifications from the Alkemio notifications service. The blacklist will be provided via existing configuration mechanisms, applied centrally in the email sending pipeline after recipient resolution, and enforced consistently across all notification types. Blacklisted recipients will be filtered out before handoff to the email transport, with clear logging/metrics so operations can observe blocked sends and diagnose issues when users report missing emails.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: Node.js 22.x (service), Node.js 20–22 (lib)  
+**Primary Dependencies**: NestJS 11 (service), TypeScript 5.8, Nunjucks email templates, existing notification services in `service/src/services/notification`  
+**Storage**: N/A (blacklist stored via configuration only; no persistent DB changes)  
+**Testing**: Jest (service tests via `npm test`), TypeScript compiler checks for `lib` and `service`  
+**Target Platform**: Linux server (Docker/Kubernetes deployment as per existing manifests)
+**Project Type**: Backend notifications microservice + shared TypeScript DTO library  
+**Performance Goals**: Negligible additional latency for blacklist checks; per-notification blacklist evaluation should be O(N) in number of recipients and cheap relative to existing processing  
+**Constraints**: Must not introduce new runtime services or storage; must work within existing config and deployment flows; feature must be safe-by-default (fail-open vs fail-closed behavior documented). Fail-open vs fail-closed behavior for v1: if blacklist configuration is missing or invalid, the system will **fail-open** (treat the blacklist as empty and log a warning) to avoid blocking all notifications due to configuration mistakes. Blacklist evaluation itself must not cause email sends to fail; failures in blacklist parsing are surfaced via logs only.  
+**Scale/Scope**: Intended to support all notifications emitted by the service, with blacklist size expected to be small-to-moderate (dozens to low hundreds of email addresses) in typical deployments
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Confirm this feature aligns with the Alkemio Notifications Constitution:
+
+- Client–server–notifications integration is explicitly modeled via `lib/`
+  DTOs and corresponding service/template changes where needed. For this
+  feature, the core behavior (blacklist enforcement) lives in the service
+  and does not require contract changes unless we later decide to expose
+  blacklist state via events or APIs.
+- Implementation follows existing structure and tooling in `service/` and
+  `lib/` (no ad-hoc scripts or parallel frameworks). Blacklist checks will
+  be implemented as a small, testable service/component in
+  `service/src/services/notification` and wired into the existing
+  notification orchestration flow.
+- Rapid feedback and validation loops are defined: local Jest tests in
+  `service/` will cover blacklist behavior; end-to-end validation will use
+  existing quickstart flows (RabbitMQ + mailslurper) to verify that
+  blacklisted addresses never receive emails while others do.
+- Contract changes will be avoided for v1; if any DTO additions are later
+  required (for audit or configuration), they will be added in `lib/src/dto/**`
+  and rolled out according to backwards-compatibility guidelines.
+- Observability and simplicity are central: blacklist configuration is
+  provided via existing config, and log entries/metrics will clearly label
+  when a recipient was skipped due to the blacklist.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-create-configurable-black/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+lib/
+  src/
+    dto/
+      # No DTO changes expected for v1; if later required,
+      # new or extended DTOs will be added here.
+
+service/
+  src/
+    config/
+      configuration.ts          # Extend to expose blacklist config (e.g. array of emails)
+    services/
+      notification/
+        notification.service.ts # Wire blacklist checks into recipient processing
+        # Potential new file for blacklist logic, e.g.:
+        # notification.blacklist.service.ts
+    # Existing email templates remain unchanged; blacklist operates at
+    # recipient selection/sending layer, not per-template.
+
+  test/
+    # Add/extend unit and integration tests around notification service
+    # to cover blacklist behavior.
+```
+
+**Structure Decision**: Reuse the existing `lib/` and `service/` layout. Implement blacklist logic as a dedicated component/service under `service/src/services/notification` and configure it via `service/src/config/configuration.ts`, without introducing new top-level projects or directories.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/001-create-configurable-black/quickstart.md
+++ b/specs/001-create-configurable-black/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Configurable Email Blacklist for Notifications
+
+## Configuring the Blacklist
+
+- Configuration mechanism (v1): A list of exact email addresses provided via an environment variable or equivalent configuration key (e.g., `NOTIFICATIONS_EMAIL_BLACKLIST`).
+- Example (environment variable):
+
+  - `NOTIFICATIONS_EMAIL_BLACKLIST="blocked1@example.org,blocked2@example.org"`
+
+- Empty or missing configuration:
+  - Treated as "no blacklist" (empty list).
+  - A warning is logged once at startup.
+
+## Reload / Restart Behavior
+
+- Changes to the blacklist take effect when:
+  - The notifications service is restarted (config is re-read at startup).
+- In-flight notifications:
+  - Notifications already being processed use the configuration that was loaded when processing began.
+  - Newly processed notifications after restart use the updated configuration.
+
+## End-to-End Validation (Constitution E2E Path)
+
+Use T015 (see `tasks.md`) or an equivalent manual flow:
+
+1. Configure a blacklist including `blocked@example.org`.
+2. Trigger a notification to `blocked@example.org` and `allowed@example.org`.
+3. Verify:
+   - Only `allowed@example.org` receives an email (for example, via mailslurper).
+   - Logs contain a structured entry indicating `blocked@example.org` was skipped due to the blacklist.

--- a/specs/001-create-configurable-black/research.md
+++ b/specs/001-create-configurable-black/research.md
@@ -1,0 +1,30 @@
+# Research Notes: Configurable Email Blacklist
+
+## Logging Format for Blacklist Blocks
+
+Proposed log fields (JSON or structured logger fields):
+
+- `event`: `"notification_blacklist_block"`
+- `recipient_email`: `<blocked email>`
+- `reason`: `"blacklisted"`
+- `notification_type`: `<event/template identifier>`
+- `correlation_id` or `event_id`: `<existing ID where available>`
+
+These fields underpin SC-003 (operations can identify the reason for a block quickly).
+
+## Metrics (If Available)
+
+- Metric name (example): `notifications_blacklist_blocks_total`
+- Labels:
+  - `notification_type`
+  - (optional) `tenant_id` or similar, if easily available
+
+This metric supports monitoring trends and provides evidence for SC-004 (ticket reduction).
+
+## Success Criteria Measurement Notes
+
+- SC-003 (investigation time):
+  - Measured qualitatively via incident runbooks; logging format and correlation IDs must allow operators to identify blacklist blocks in under 5 minutes during troubleshooting.
+- SC-004 (ticket reduction):
+  - Track support tickets tagged with an "unwanted-notification"-style label before and after rollout.
+  - This feature is a contributing factor; exact percentage is approximate and depends on adoption and upstream behavior.

--- a/specs/001-create-configurable-black/spec.md
+++ b/specs/001-create-configurable-black/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: Configurable Email Blacklist for Notifications
+
+**Feature Branch**: `001-create-configurable-black`  
+**Created**: 2025-11-18  
+**Status**: Draft  
+**Input**: User description: "create a configurable black list of emails that should not receive notifications"
+
+## Clarifications
+
+### Session 2025-11-18
+
+- Q: Should the blacklist support only exact email addresses, or also domain-level patterns and wildcards? 
+  → A: Support only exact email addresses for v1.
+ - Q: Should the blacklist take precedence over user-level subscription preferences, and is it global across all tenants/spaces? 
+  → A: Blacklist is global and always takes precedence.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Prevent emails to blacklisted addresses (Priority: P1)
+
+An operations administrator maintains a list of email addresses that must not receive any notification emails (for example, legal hold addresses, test accounts, or users who must be blocked at the notifications layer). When the system attempts to send a notification email to any blacklisted address, the email is not sent and the event is logged, while notifications to non-blacklisted addresses continue to work normally.
+
+**Why this priority**: This prevents misdelivery of notifications to sensitive or blocked addresses and avoids potential legal, privacy, or abuse issues. It protects the platform even if upstream systems misconfigure recipients.
+
+**Independent Test**: Configure at least one blacklisted email address, trigger an event that would send a notification to that address, and verify that no email is sent to the blacklisted address while other recipients still receive their notifications.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured blacklist containing `blocked@example.org`, **When** a notification is triggered to `blocked@example.org`, **Then** the notifications service must not send an email to `blocked@example.org` and must record that the send was blocked by the blacklist.
+2. **Given** a configured blacklist containing `blocked@example.org` and a recipient list `blocked@example.org`, `allowed@example.org`, **When** a notification is triggered to both recipients, **Then** only `allowed@example.org` receives the notification email and the blocked address is skipped with an appropriate log entry.
+
+---
+
+### User Story 2 - Configure and manage the blacklist (Priority: P2)
+
+An operations administrator can configure and update the blacklist of email addresses without changing application code or rebuilding the service. They can add or remove addresses (and, if supported, domain-level patterns) and have the changes applied by the notifications service within a predictable time frame.
+
+**Why this priority**: Blacklist management must be practical and safe to operate; otherwise the feature will not be usable in real environments. Configuration-based control reduces deployment overhead and allows quick reaction to incidents.
+
+**Independent Test**: Start the notifications service with an initial blacklist configuration, trigger events to verify behavior, then change the configuration (e.g., add or remove an address) and confirm that subsequent notifications respect the updated blacklist without code changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running notifications service and a configuration file or environment variable containing a blacklist with `blocked1@example.org`, **When** the operator updates the configuration to add `blocked2@example.org` and reloads/restarts the service according to documented steps, **Then** subsequent notifications to either `blocked1@example.org` or `blocked2@example.org` are blocked.
+
+---
+
+### User Story 3 - Observe and audit blacklist behavior (Priority: P3)
+
+An operations or support engineer can observe when notifications are blocked due to the blacklist and, if needed, audit which addresses were affected over a period of time using logs or metrics. They can distinguish blacklist blocks from other failures (for example, SMTP errors).
+
+**Why this priority**: Observability helps diagnose unexpected missing emails and ensures the blacklist does not silently hide configuration errors or regressions.
+
+**Independent Test**: Trigger notifications to blacklisted and non-blacklisted addresses and verify that logs or metrics clearly indicate when the blacklist caused a notification to be skipped, distinct from other errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured blacklist and logging enabled, **When** a notification to a blacklisted address is blocked, **Then** the service logs a structured entry indicating that the recipient was blacklisted and no send attempt was made.
+2. **Given** a configured blacklist and metrics/monitoring, **When** a notification to a blacklisted address is blocked, **Then** an appropriate counter or metric is incremented so that the rate of blacklist blocks can be monitored over time (subject to existing observability capabilities).
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+- What happens when the recipient list contains only blacklisted addresses? The system should not send any emails and should treat the notification as successfully processed but fully filtered, with clear logging.
+- What happens when the blacklist configuration is empty or missing? The system should behave as it does today, sending notifications to all eligible recipients and logging that no blacklist is applied if relevant.
+- How does the system handle invalid email formats in the blacklist configuration? Invalid entries should be ignored with a warning, without breaking notification delivery for valid recipients.
+- How does the system handle domain-level blocking (e.g., `@example.org`) versus specific addresses? For v1, the blacklist supports only exact email addresses (e.g., `user@example.org`); domain-level or wildcard blocking is out of scope.
+- What happens if the same email address appears multiple times in configuration (duplicates)? The system should treat the address as blacklisted once without error.
+- How does the system behave when configuration is reloaded while notifications are in-flight? In-flight notifications may use the previous configuration; newly processed notifications must use the latest configuration after reload/restart.
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: The notifications service MUST support a configurable blacklist of email addresses (exact addresses only in v1) that are excluded from receiving any notification emails.
+- **FR-002**: The blacklist MUST be configurable via existing configuration mechanisms (for example, configuration files or environment variables) without requiring changes to application code or rebuilding the service.
+- **FR-003**: The notifications service MUST evaluate the blacklist after determining the intended recipients and before attempting to send emails, ensuring that blacklisted addresses are removed from the final recipient list passed to the email transport.
+- **FR-004**: The blacklist MUST apply consistently across all notification types and templates handled by the service, regardless of the triggering event or domain (space, organization, platform, user, etc.).
+- **FR-005**: When a recipient is skipped due to the blacklist, the service MUST log a clear, structured message indicating the recipient, the reason (blacklisted), and enough context to correlate with the originating notification event, without logging sensitive content from the email body.
+- **FR-006**: The system MUST ensure that blacklisted recipients do not receive notifications even if they appear multiple times or via different paths in the notification flow (for example, as direct recipients and as part of a group or role expansion).
+- **FR-007**: The feature MUST include at least one independently testable end-to-end scenario where a notification is triggered, recipients are resolved, the blacklist is applied, and the absence of email to blacklisted addresses is verified.
+- **FR-008**: Any changes to DTOs or event payloads (if needed for auditing or configuration) MUST be captured in `lib/src/dto/**` and referenced here, but the core blacklist behavior SHOULD be implemented within the service configuration and email sending pipeline where possible.
+- **FR-009**: The system MUST define and document how conflicts between this blacklist and any existing opt-out/unsubscribe mechanisms are resolved. The blacklist is global across all tenants/spaces and always takes precedence: if an email address is blacklisted, no notifications are sent to it regardless of user-level subscription preferences.
+
+### Key Entities *(include if feature involves data)*
+
+- **Email Recipient**: Represents an individual email address resolved as a target for a notification. Key attributes include the email address string and any associated user or domain context used for logging (for example, user ID or tenant ID), but the blacklist operates purely on the email address value.
+- **Email Blacklist Entry**: Represents a single configured item in the blacklist as an **exact email address** (e.g., `user@example.org`) in v1. Future versions MAY add support for patterns (for example, domain-level entries), but this feature explicitly scopes blacklist entries to exact addresses only.
+- **Notification Event**: Existing concept representing an event that triggers one or more notification emails. This feature does not change event structure but relies on resolved recipients being filtered against the blacklist before delivery.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of emails addressed exclusively to blacklisted recipients are blocked by the notifications service (i.e., no emails are sent to those recipients through this system).
+- **SC-002**: In mixed recipient lists, at least 99% of non-blacklisted recipients continue to receive notifications successfully while blacklisted recipients are consistently filtered out.
+- **SC-003**: Operations teams can identify the reason for a blocked notification due to the blacklist from logs or monitoring in under 5 minutes during incident investigation, based on clear and structured logging.
+- **SC-004**: Support tickets related to unwanted notifications being sent to known blocked or test addresses are reduced by at least 50% within one release cycle after the feature is enabled (where such tickets previously existed).
+
+### Future Extensions
+
+- Pattern or domain-level blacklist entries (for example, `@example.org`) may be considered as a separate feature; this specification explicitly excludes them from v1.

--- a/specs/001-create-configurable-black/tasks.md
+++ b/specs/001-create-configurable-black/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Configurable Email Blacklist for Notifications
+
+## Phase 1 – Setup & Constitution Alignment
+
+- [ ] T001 Ensure `service/` and `lib/` dependencies installed (`npm install` in `service/` and `lib/`)
+- [ ] T002 Verify existing build and test commands for `service/` (`npm run build`, `npm test` from `service/`)
+- [ ] T003 Confirm no DTO changes are required for v1 by reviewing `lib/src/dto/**` against spec requirements
+- [ ] T004 Document constitution alignment in `specs/001-create-configurable-black/plan.md` (update if implementation deviates)
+
+## Phase 2 – Foundational Infrastructure
+
+- [ ] T005 Add blacklist configuration option to `service/src/config/configuration.ts` (e.g., array of exact email addresses)
+- [ ] T006 [P] Thread blacklist configuration through `service/src/config/index.ts` and any related config helpers
+- [ ] T007 [P] Add typed configuration property for blacklist to `service/src/config/aliases.ts` or relevant config typings
+- [ ] T008 Add basic unit tests (if present) for configuration loading to ensure blacklist config is read correctly in `service/test/**`
+
+## Phase 3 – User Story 1 (US1): Prevent emails to blacklisted addresses
+
+**Goal**: Ensure notifications are never sent to blacklisted email addresses while non-blacklisted recipients continue to receive emails.
+
+**Independent Test Criteria**: Trigger notifications to at least one blacklisted and one non-blacklisted recipient and verify that only non-blacklisted recipients receive emails.
+
+- [ ] T009 [US1] Identify the central notification sending path in `service/src/services/notification/notification.service.ts` (where recipient lists are finalized before sending)
+- [ ] T010 [P] [US1] Create a dedicated blacklist helper/service (e.g., `service/src/services/notification/notification.blacklist.service.ts`) that exposes a function to filter recipients based on configured blacklist
+- [ ] T011 [P] [US1] Implement recipient filtering in `notification.blacklist.service.ts` using exact email address matching only
+- [ ] T012 [US1] Inject and wire the blacklist helper/service into `notification.service.ts`, ensuring the blacklist filter runs after recipient resolution and before sending
+- [ ] T013 [US1] Handle edge case where all recipients are blacklisted in `notification.service.ts` (no send is attempted, but flow is treated as successfully processed with appropriate logging)
+- [ ] T014 [P] [US1] Add unit tests in `service/test/**` to cover: single blacklisted recipient, mixed (blacklisted + allowed), and no blacklisted recipients
+- [ ] T015 [US1] [Constitution E2E] Add an end-to-end style test or integration-style test (if feasible in `service/test/**`) that simulates a notification with mixed recipients and asserts that only allowed recipients are sent to the email transport layer, satisfying the constitution's end-to-end validation requirement.
+
+## Phase 4 – User Story 2 (US2): Configure and manage the blacklist
+
+**Goal**: Allow operations to configure and update the blacklist via existing configuration mechanisms without code changes.
+
+**Independent Test Criteria**: Start the service with an initial blacklist, change the configuration (e.g., add/remove email), restart/reload as documented, and observe updated behavior.
+
+- [ ] T016 [US2] Decide and document the configuration mechanism for the blacklist (e.g., environment variable, YAML config) in `specs/001-create-configurable-black/quickstart.md`
+- [ ] T017 [US2] Implement configuration parsing for the blacklist in `service/src/config/configuration.ts` (including empty/missing config handling)
+- [ ] T018 [P] [US2] Implement validation of configured blacklist entries (ignore invalid email formats with a warning) in `service/src/config/configuration.ts` or the blacklist helper
+- [ ] T019 [US2] Ensure configuration reload behavior is documented (restart vs hot-reload) in `specs/001-create-configurable-black/quickstart.md`
+- [ ] T020 [P] [US2] Add tests in `service/test/**` verifying that different blacklist configurations (empty, single address, multiple addresses) are correctly surfaced into the blacklist helper/service
+
+- [ ] T020a [US2] Extend configuration tests to cover duplicate blacklist entries (same email repeated) and assert that behavior is equivalent to a single entry (no errors, recipient still blocked).
+- [ ] T020b [US2] Add a test or documented note covering behavior of notifications across service restarts (for example, ensure that config changes only affect notifications processed after restart, and capture this explicitly in test descriptions or docs).
+
+## Phase 5 – User Story 3 (US3): Observe and audit blacklist behavior
+
+**Goal**: Provide clear logs/metrics to observe when notifications are blocked due to the blacklist.
+
+**Independent Test Criteria**: Trigger notifications to blacklisted and non-blacklisted addresses and verify distinct, structured logging/metrics for blacklist blocks.
+
+- [ ] T021 [US3] Define the logging format for blacklist blocks (fields such as recipient email, reason, notification type) and document it in `specs/001-create-configurable-black/research.md` or `quickstart.md`
+- [ ] T022 [US3] Implement logging in `notification.blacklist.service.ts` or `notification.service.ts` when recipients are filtered due to blacklist
+- [ ] T023 [P] [US3] If metrics/monitoring integration exists, increment or emit a metric for blacklist blocks in the appropriate location in `service/src/**`
+- [ ] T024 [P] [US3] Add tests in `service/test/**` to assert that logs/metrics are produced when a recipient is blocked by the blacklist (using existing logging test patterns)
+
+## Phase 6 – Polish & Cross-Cutting Concerns
+
+- [ ] T025 Update `service/README.md` to briefly describe the blacklist feature and how to configure it
+- [ ] T026 Add operational guidance and example scenarios to `specs/001-create-configurable-black/quickstart.md` (e.g., sample config, how to verify behavior with mailslurper)
+- [ ] T027 Run full `service` validation: `npm run build`, `npm test`, `npm run lint` from `service/`
+- [ ] T028 [P] Validate `lib` still builds successfully (`npm run build` from `lib/`)
+- [ ] T029 Review `specs/001-create-configurable-black/spec.md`, `plan.md`, and this `tasks.md` for consistency and update any drift before opening PR
+
+## Dependencies & Story Order
+
+- US1 depends on Phase 2 foundational configuration wiring.
+- US2 depends on core blacklist enforcement existing (US1) so that configuration changes have observable effects.
+- US3 depends on US1 (enforcement) and partially on US2 (configuration) to produce meaningful logs/metrics.
+
+Recommended implementation order: Phase 1 → Phase 2 → US1 (Phase 3) → US2 (Phase 4) → US3 (Phase 5) → Phase 6.
+
+## Parallel Execution Examples
+
+- T006, T007, and T008 can be implemented in parallel once T005 is defined.
+- T010, T011, and T014 can be worked on in parallel after T009 identifies the central notification path.
+- T018 and T020 can run in parallel after T017 is in place.
+- T023 and T024 can be implemented in parallel once T022 defines where blacklist blocks are logged/emitted.
+- T027 and T028 can run in parallel at the end of implementation.


### PR DESCRIPTION
Adds a global email blacklist to prevent notifications from being sent to specific addresses, configured via environment variable without code changes or redeployment.

## Implementation

**Configuration**
- Environment variable: `NOTIFICATIONS_EMAIL_BLACKLIST` (comma-separated exact email addresses)
- Fail-safe: invalid/missing config logs warning, doesn't break service
- Case-insensitive matching, duplicate-safe

**Core Logic**
- New `NotificationBlacklistService` filters recipients before email transport
- Integrated into `NotificationService` between recipient resolution and sending
- All notification types affected consistently

**Observability**
- Structured logging when recipients blocked: `event: notification_blacklist_block`, includes recipient, notification type, correlation ID
- Empty recipient list after filtering logged appropriately

## Usage

```yaml
# notifications.yml or environment
NOTIFICATIONS_EMAIL_BLACKLIST: "blocked@example.org,test@internal.com"
```

```typescript
// Automatic filtering in notification pipeline
// blocked@example.org never receives emails
// Other recipients unaffected
```

## Test Coverage

22 new tests covering:
- Single/multiple/all recipients blacklisted
- Empty/invalid/duplicate config handling
- Mixed blacklisted + allowed recipients
- Logging verification
- Edge cases (empty lists, invalid emails in config)

Existing 15 tests unchanged and passing.
