### PR TITLE
GraphQL-sourced notification email blacklist with automatic sync (squashed)

### DIFF
--- a/service/graphql/blacklistLookup.graphql
+++ b/service/graphql/blacklistLookup.graphql
@@ -1,0 +1,10 @@
+query BlacklistLookup {
+  platform {
+    id
+    settings {
+      integration {
+        notificationEmailBlacklist
+      }
+    }
+  }
+}

--- a/service/notifications.yml
+++ b/service/notifications.yml
@@ -92,6 +92,19 @@ alkemio:
   endpoint: ${ALKEMIO_SERVER_ENDPOINT}:http://localhost:3000/api/private/non-interactive/graphql
   webclient_endpoint: ${ALKEMIO_WEBCLIENT_ENDPOINT}:http://localhost:3000
   webclient_invitations_path: /home?dialog=invitations
+  # GraphQL blacklist sync configuration
+  blacklist_sync:
+    # Enable/disable GraphQL-based blacklist synchronization
+    enabled: ${ALKEMIO_BLACKLIST_SYNC_ENABLED}:true
+    # Interval for refreshing the blacklist from GraphQL (in milliseconds)
+    # Default: 300000 (5 minutes)
+    interval_ms: ${ALKEMIO_BLACKLIST_SYNC_INTERVAL_MS}:300000
+    # Initial delay before starting exponential backoff (in milliseconds)
+    # Default: 250
+    initial_backoff_ms: ${ALKEMIO_BLACKLIST_SYNC_INITIAL_BACKOFF_MS}:250
+    # Maximum delay for exponential backoff (in milliseconds)
+    # Default: 30000 (30 seconds)
+    max_backoff_ms: ${ALKEMIO_BLACKLIST_SYNC_MAX_BACKOFF_MS}:30000
 
 kratos:
   public_endpoint: ${KRATOS_API_PUBLIC_ENDPOINT}:http://localhost:3000/ory/kratos/public

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -22,6 +22,8 @@
         "apollo-server-express": "^3.13.0",
         "cross-env": "^10.0.0",
         "dotenv": "^10.0.0",
+        "graphql": "^16.12.0",
+        "graphql-request": "^3.7.0",
         "markdown-to-text": "^0.1.1",
         "module-alias": "^2.2.3",
         "nest-winston": "^1.10.2",
@@ -141,19 +143,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/schema-ast": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz",
@@ -166,19 +155,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript": {
@@ -195,23 +171,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript-graphql-request": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.9.tgz",
-      "integrity": "sha512-Vtv5qymUXcR4UFdHOlJHzK5TN+CZUwMwFDGb3n4Gjcr4yln1BWbUb7DXgD0GHzpXwDIj5G2XmJnFtr0jihBfrg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^3.0.0",
-        "@graphql-codegen/visitor-plugin-common": "2.13.1",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-        "graphql-request": "^3.4.0 || ^4.0.0 || ~5.0.0 || ~5.1.0",
-        "graphql-tag": "^2.0.0"
       }
     },
     "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript-operations": {
@@ -251,19 +210,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
       "version": "2.13.8",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz",
@@ -283,75 +229,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/typescript/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
-      "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-tools/optimize": "^1.3.0",
-        "@graphql-tools/relay-operation-optimizer": "^6.5.0",
-        "@graphql-tools/utils": "^8.8.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.14",
-        "dependency-graph": "^0.11.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
-      "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^8.8.0",
-        "change-case-all": "1.0.14",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
-      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/@alkemio/client-lib/node_modules/@graphql-tools/optimize": {
@@ -380,19 +257,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@alkemio/client-lib/node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@alkemio/client-lib/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -404,29 +268,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@alkemio/client-lib/node_modules/graphql-request": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
-      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.0.6",
-        "extract-files": "^9.0.0",
-        "form-data": "^3.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "14 - 16"
       }
     },
     "node_modules/@alkemio/client-lib/node_modules/graphql-upload": {
@@ -3130,6 +2971,264 @@
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/typescript-graphql-request": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.9.tgz",
+      "integrity": "sha512-Vtv5qymUXcR4UFdHOlJHzK5TN+CZUwMwFDGb3n4Gjcr4yln1BWbUb7DXgD0GHzpXwDIj5G2XmJnFtr0jihBfrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^3.0.0",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-request": "^3.4.0 || ^4.0.0 || ~5.0.0 || ~5.1.0",
+        "graphql-tag": "^2.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@ardatan/relay-compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+      "integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.14.0",
+        "@babel/generator": "^7.14.0",
+        "@babel/parser": "^7.14.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.4.0",
+        "chalk": "^4.0.0",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^3.0.0",
+        "glob": "^7.1.1",
+        "immutable": "~3.7.6",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "12.0.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "relay-compiler": "bin/relay-compiler"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+      "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.7.2",
+        "@graphql-tools/optimize": "^1.3.0",
+        "@graphql-tools/relay-operation-optimizer": "^6.5.0",
+        "@graphql-tools/utils": "^8.8.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+      "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^8.8.0",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+      "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-tools/optimize": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+      "integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "6.5.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+      "integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-graphql-request/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@graphql-codegen/typescript-operations": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.6.1.tgz",
@@ -4156,19 +4255,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/mock/node_modules/value-or-promise": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
@@ -4399,9 +4485,12 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.10.1",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
       "license": "MIT",
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -13111,10 +13200,12 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "15.6.0",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-config": {
@@ -13249,8 +13340,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/graphql-request": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
     "node_modules/graphql-tag": {
-      "version": "2.12.5",
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -13259,7 +13366,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/gtoken": {
@@ -21936,17 +22043,6 @@
             "import-from": "4.0.0",
             "lodash": "~4.17.0",
             "tslib": "~2.4.0"
-          },
-          "dependencies": {
-            "@graphql-tools/utils": {
-              "version": "9.2.1",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-              "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-              "requires": {
-                "@graphql-typed-document-node/core": "^3.1.1",
-                "tslib": "^2.4.0"
-              }
-            }
           }
         },
         "@graphql-codegen/schema-ast": {
@@ -21957,17 +22053,6 @@
             "@graphql-codegen/plugin-helpers": "^3.1.2",
             "@graphql-tools/utils": "^9.0.0",
             "tslib": "~2.4.0"
-          },
-          "dependencies": {
-            "@graphql-tools/utils": {
-              "version": "9.2.1",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-              "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-              "requires": {
-                "@graphql-typed-document-node/core": "^3.1.1",
-                "tslib": "^2.4.0"
-              }
-            }
           }
         },
         "@graphql-codegen/typescript": {
@@ -21998,27 +22083,7 @@
                 "parse-filepath": "^1.0.2",
                 "tslib": "~2.4.0"
               }
-            },
-            "@graphql-tools/utils": {
-              "version": "9.2.1",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-              "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-              "requires": {
-                "@graphql-typed-document-node/core": "^3.1.1",
-                "tslib": "^2.4.0"
-              }
             }
-          }
-        },
-        "@graphql-codegen/typescript-graphql-request": {
-          "version": "4.5.9",
-          "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.9.tgz",
-          "integrity": "sha512-Vtv5qymUXcR4UFdHOlJHzK5TN+CZUwMwFDGb3n4Gjcr4yln1BWbUb7DXgD0GHzpXwDIj5G2XmJnFtr0jihBfrg==",
-          "requires": {
-            "@graphql-codegen/plugin-helpers": "^3.0.0",
-            "@graphql-codegen/visitor-plugin-common": "2.13.1",
-            "auto-bind": "~4.0.0",
-            "tslib": "~2.4.0"
           }
         },
         "@graphql-codegen/typescript-operations": {
@@ -22049,64 +22114,6 @@
                 "parse-filepath": "^1.0.2",
                 "tslib": "~2.4.0"
               }
-            },
-            "@graphql-tools/utils": {
-              "version": "9.2.1",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-              "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-              "requires": {
-                "@graphql-typed-document-node/core": "^3.1.1",
-                "tslib": "^2.4.0"
-              }
-            }
-          }
-        },
-        "@graphql-codegen/visitor-plugin-common": {
-          "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
-          "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
-          "requires": {
-            "@graphql-codegen/plugin-helpers": "^2.7.2",
-            "@graphql-tools/optimize": "^1.3.0",
-            "@graphql-tools/relay-operation-optimizer": "^6.5.0",
-            "@graphql-tools/utils": "^8.8.0",
-            "auto-bind": "~4.0.0",
-            "change-case-all": "1.0.14",
-            "dependency-graph": "^0.11.0",
-            "graphql-tag": "^2.11.0",
-            "parse-filepath": "^1.0.2",
-            "tslib": "~2.4.0"
-          },
-          "dependencies": {
-            "@graphql-codegen/plugin-helpers": {
-              "version": "2.7.2",
-              "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
-              "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
-              "requires": {
-                "@graphql-tools/utils": "^8.8.0",
-                "change-case-all": "1.0.14",
-                "common-tags": "1.8.2",
-                "import-from": "4.0.0",
-                "lodash": "~4.17.0",
-                "tslib": "~2.4.0"
-              }
-            },
-            "change-case-all": {
-              "version": "1.0.14",
-              "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
-              "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
-              "requires": {
-                "change-case": "^4.1.2",
-                "is-lower-case": "^2.0.2",
-                "is-upper-case": "^2.0.2",
-                "lower-case": "^2.0.2",
-                "lower-case-first": "^2.0.2",
-                "sponge-case": "^1.0.1",
-                "swap-case": "^2.0.2",
-                "title-case": "^3.0.3",
-                "upper-case": "^2.0.2",
-                "upper-case-first": "^2.0.2"
-              }
             }
           }
         },
@@ -22126,17 +22133,6 @@
             "@ardatan/relay-compiler": "12.0.0",
             "@graphql-tools/utils": "^9.2.1",
             "tslib": "^2.4.0"
-          },
-          "dependencies": {
-            "@graphql-tools/utils": {
-              "version": "9.2.1",
-              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-              "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-              "requires": {
-                "@graphql-typed-document-node/core": "^3.1.1",
-                "tslib": "^2.4.0"
-              }
-            }
           }
         },
         "find-up": {
@@ -22146,21 +22142,6 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
-          }
-        },
-        "graphql": {
-          "version": "16.11.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-          "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="
-        },
-        "graphql-request": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
-          "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
-          "requires": {
-            "cross-fetch": "^3.0.6",
-            "extract-files": "^9.0.0",
-            "form-data": "^3.0.0"
           }
         },
         "graphql-upload": {
@@ -23966,6 +23947,201 @@
         }
       }
     },
+    "@graphql-codegen/typescript-graphql-request": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-graphql-request/-/typescript-graphql-request-4.5.9.tgz",
+      "integrity": "sha512-Vtv5qymUXcR4UFdHOlJHzK5TN+CZUwMwFDGb3n4Gjcr4yln1BWbUb7DXgD0GHzpXwDIj5G2XmJnFtr0jihBfrg==",
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^3.0.0",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.4.0"
+      },
+      "dependencies": {
+        "@ardatan/relay-compiler": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+          "integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+          "requires": {
+            "@babel/core": "^7.14.0",
+            "@babel/generator": "^7.14.0",
+            "@babel/parser": "^7.14.0",
+            "@babel/runtime": "^7.0.0",
+            "@babel/traverse": "^7.14.0",
+            "@babel/types": "^7.0.0",
+            "babel-preset-fbjs": "^3.4.0",
+            "chalk": "^4.0.0",
+            "fb-watchman": "^2.0.0",
+            "fbjs": "^3.0.0",
+            "glob": "^7.1.1",
+            "immutable": "~3.7.6",
+            "invariant": "^2.2.4",
+            "nullthrows": "^1.1.1",
+            "relay-runtime": "12.0.0",
+            "signedsource": "^1.0.0",
+            "yargs": "^15.3.1"
+          }
+        },
+        "@graphql-codegen/plugin-helpers": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+          "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+          "requires": {
+            "@graphql-tools/utils": "^9.0.0",
+            "change-case-all": "1.0.15",
+            "common-tags": "1.8.2",
+            "import-from": "4.0.0",
+            "lodash": "~4.17.0",
+            "tslib": "~2.4.0"
+          }
+        },
+        "@graphql-codegen/visitor-plugin-common": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+          "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+          "requires": {
+            "@graphql-codegen/plugin-helpers": "^2.7.2",
+            "@graphql-tools/optimize": "^1.3.0",
+            "@graphql-tools/relay-operation-optimizer": "^6.5.0",
+            "@graphql-tools/utils": "^8.8.0",
+            "auto-bind": "~4.0.0",
+            "change-case-all": "1.0.14",
+            "dependency-graph": "^0.11.0",
+            "graphql-tag": "^2.11.0",
+            "parse-filepath": "^1.0.2",
+            "tslib": "~2.4.0"
+          },
+          "dependencies": {
+            "@graphql-codegen/plugin-helpers": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+              "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+              "requires": {
+                "@graphql-tools/utils": "^8.8.0",
+                "change-case-all": "1.0.14",
+                "common-tags": "1.8.2",
+                "import-from": "4.0.0",
+                "lodash": "~4.17.0",
+                "tslib": "~2.4.0"
+              }
+            },
+            "@graphql-tools/utils": {
+              "version": "8.13.1",
+              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+              "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+              "requires": {
+                "tslib": "^2.4.0"
+              }
+            },
+            "change-case-all": {
+              "version": "1.0.14",
+              "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+              "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+              "requires": {
+                "change-case": "^4.1.2",
+                "is-lower-case": "^2.0.2",
+                "is-upper-case": "^2.0.2",
+                "lower-case": "^2.0.2",
+                "lower-case-first": "^2.0.2",
+                "sponge-case": "^1.0.1",
+                "swap-case": "^2.0.2",
+                "title-case": "^3.0.3",
+                "upper-case": "^2.0.2",
+                "upper-case-first": "^2.0.2"
+              }
+            }
+          }
+        },
+        "@graphql-tools/optimize": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+          "integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/relay-operation-optimizer": {
+          "version": "6.5.18",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+          "integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+          "requires": {
+            "@ardatan/relay-compiler": "12.0.0",
+            "@graphql-tools/utils": "^9.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "@graphql-codegen/typescript-operations": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.6.1.tgz",
@@ -24654,15 +24830,6 @@
             "value-or-promise": "^1.0.12"
           }
         },
-        "@graphql-tools/utils": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-          "requires": {
-            "@graphql-typed-document-node/core": "^3.1.1",
-            "tslib": "^2.4.0"
-          }
-        },
         "value-or-promise": {
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
@@ -24827,8 +24994,11 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.10.1",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
       "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
       }
     },
@@ -30645,7 +30815,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.6.0"
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="
     },
     "graphql-config": {
       "version": "5.1.5",
@@ -30727,8 +30899,20 @@
         }
       }
     },
+    "graphql-request": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      }
+    },
     "graphql-tag": {
-      "version": "2.12.5",
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/service/package.json
+++ b/service/package.json
@@ -49,6 +49,8 @@
     "apollo-server-express": "^3.13.0",
     "cross-env": "^10.0.0",
     "dotenv": "^10.0.0",
+    "graphql": "^16.12.0",
+    "graphql-request": "^3.7.0",
     "markdown-to-text": "^0.1.1",
     "module-alias": "^2.2.3",
     "nest-winston": "^1.10.2",

--- a/service/src/services/notification/blacklist-sync.service.spec.ts
+++ b/service/src/services/notification/blacklist-sync.service.spec.ts
@@ -1,0 +1,352 @@
+import { Test } from '@nestjs/testing';
+import { BlacklistSyncService } from './blacklist-sync.service';
+import { ConfigService } from '@nestjs/config';
+import { MockWinstonProvider } from '@test/mocks';
+import { GraphQLClient } from 'graphql-request';
+
+// Mock GraphQLClient
+jest.mock('graphql-request');
+
+describe('BlacklistSyncService', () => {
+  let service: BlacklistSyncService;
+  let mockGraphQLClient: jest.Mocked<GraphQLClient>;
+
+  const mockSuccessResponse = {
+    platform: {
+      id: 'test-platform-id',
+      settings: {
+        integration: {
+          notificationEmailBlacklist: [
+            'blocked1@example.com',
+            'blocked2@example.com',
+            'BLOCKED3@EXAMPLE.COM', // Test case normalization
+          ],
+        },
+      },
+    },
+  };
+
+  const createServiceWithConfig = async (config: any) => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue({
+              endpoint: 'http://localhost:3000/graphql',
+              blacklist_sync: config,
+            }),
+          },
+        },
+        MockWinstonProvider,
+        BlacklistSyncService,
+      ],
+    }).compile();
+
+    return moduleRef.get<BlacklistSyncService>(BlacklistSyncService);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset GraphQLClient mock
+    mockGraphQLClient = {
+      request: jest.fn(),
+    } as any;
+    (
+      GraphQLClient as jest.MockedClass<typeof GraphQLClient>
+    ).mockImplementation(() => mockGraphQLClient);
+  });
+
+  describe('Initialization with sync enabled', () => {
+    it('should initialize with default configuration when sync is enabled', async () => {
+      service = await createServiceWithConfig({ enabled: true });
+
+      expect(service.isSyncEnabled()).toBe(true);
+      expect(GraphQLClient).toHaveBeenCalledWith(
+        'http://localhost:3000/graphql',
+        expect.any(Object)
+      );
+    });
+
+    it('should use custom configuration values', async () => {
+      service = await createServiceWithConfig({
+        enabled: true,
+        interval_ms: 60000,
+        initial_backoff_ms: 500,
+        max_backoff_ms: 60000,
+      });
+
+      expect(service.isSyncEnabled()).toBe(true);
+    });
+  });
+
+  describe('Initialization with sync disabled', () => {
+    it('should not initialize GraphQL client when sync is disabled', async () => {
+      service = await createServiceWithConfig({ enabled: false });
+
+      expect(service.isSyncEnabled()).toBe(false);
+      expect(service.getCurrentSnapshot()).toBeNull();
+    });
+  });
+
+  describe('Happy path sync behavior', () => {
+    beforeEach(async () => {
+      service = await createServiceWithConfig({ enabled: true });
+    });
+
+    it('should fetch and normalize blacklist successfully', async () => {
+      mockGraphQLClient.request.mockResolvedValueOnce(mockSuccessResponse);
+
+      // Trigger onModuleInit to perform initial sync
+      await service.onModuleInit();
+
+      // Wait a bit for async operation
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.emails.size).toBe(3);
+      expect(snapshot?.emails.has('blocked1@example.com')).toBe(true);
+      expect(snapshot?.emails.has('blocked2@example.com')).toBe(true);
+      expect(snapshot?.emails.has('blocked3@example.com')).toBe(true); // Normalized
+      expect(snapshot?.platformId).toBe('test-platform-id');
+    });
+
+    it('should deduplicate email addresses', async () => {
+      const responseWithDuplicates = {
+        platform: {
+          id: 'test-platform-id',
+          settings: {
+            integration: {
+              notificationEmailBlacklist: [
+                'blocked@example.com',
+                'BLOCKED@EXAMPLE.COM',
+                'blocked@example.com',
+              ],
+            },
+          },
+        },
+      };
+
+      mockGraphQLClient.request.mockResolvedValueOnce(responseWithDuplicates);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot?.emails.size).toBe(1);
+      expect(snapshot?.emails.has('blocked@example.com')).toBe(true);
+    });
+
+    it('should handle empty blacklist correctly', async () => {
+      const emptyResponse = {
+        platform: {
+          id: 'test-platform-id',
+          settings: {
+            integration: {
+              notificationEmailBlacklist: [],
+            },
+          },
+        },
+      };
+
+      mockGraphQLClient.request.mockResolvedValueOnce(emptyResponse);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.emails.size).toBe(0);
+    });
+  });
+
+  describe('Normalization and validation', () => {
+    beforeEach(async () => {
+      service = await createServiceWithConfig({ enabled: true });
+    });
+
+    it('should filter out invalid email addresses', async () => {
+      const responseWithInvalidEmails = {
+        platform: {
+          id: 'test-platform-id',
+          settings: {
+            integration: {
+              notificationEmailBlacklist: [
+                'valid@example.com',
+                'invalid-email', // No @
+                '@no-local-part.com',
+                'no-domain@', // No domain
+                'no-tld@example',
+                '  valid2@example.com  ', // With whitespace (should be trimmed)
+              ],
+            },
+          },
+        },
+      };
+
+      mockGraphQLClient.request.mockResolvedValueOnce(
+        responseWithInvalidEmails
+      );
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot?.emails.size).toBe(2);
+      expect(snapshot?.emails.has('valid@example.com')).toBe(true);
+      expect(snapshot?.emails.has('valid2@example.com')).toBe(true);
+    });
+
+    it('should trim and lowercase all email addresses', async () => {
+      const responseWithVariations = {
+        platform: {
+          id: 'test-platform-id',
+          settings: {
+            integration: {
+              notificationEmailBlacklist: [
+                '  USER@EXAMPLE.COM  ',
+                'AnotherUser@Example.Com',
+              ],
+            },
+          },
+        },
+      };
+
+      mockGraphQLClient.request.mockResolvedValueOnce(responseWithVariations);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot?.emails.has('user@example.com')).toBe(true);
+      expect(snapshot?.emails.has('anotheruser@example.com')).toBe(true);
+    });
+
+    it('should enforce 250 entry limit', async () => {
+      const largeBlacklist = Array.from(
+        { length: 300 },
+        (_, i) => `user${i}@example.com`
+      );
+      const responseWithManyEmails = {
+        platform: {
+          id: 'test-platform-id',
+          settings: {
+            integration: {
+              notificationEmailBlacklist: largeBlacklist,
+            },
+          },
+        },
+      };
+
+      mockGraphQLClient.request.mockResolvedValueOnce(responseWithManyEmails);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot?.emails.size).toBe(250);
+    });
+  });
+
+  describe('Failure scenarios', () => {
+    beforeEach(async () => {
+      service = await createServiceWithConfig({ enabled: true });
+    });
+
+    it('should handle network errors gracefully', async () => {
+      mockGraphQLClient.request.mockRejectedValueOnce(
+        new Error('Network error')
+      );
+
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Should not have a snapshot on first failure
+      const snapshot = service.getCurrentSnapshot();
+      expect(snapshot).toBeNull();
+      expect(service.getConsecutiveFailures()).toBeGreaterThan(0);
+    });
+
+    it('should retain last successful snapshot on subsequent failures', async () => {
+      // First successful sync
+      mockGraphQLClient.request.mockResolvedValueOnce(mockSuccessResponse);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const firstSnapshot = service.getCurrentSnapshot();
+      expect(firstSnapshot).not.toBeNull();
+      expect(firstSnapshot?.emails.size).toBe(3);
+
+      // Simulate failure on next sync
+      mockGraphQLClient.request.mockRejectedValueOnce(
+        new Error('Network error')
+      );
+
+      // Manually trigger another sync
+      await (service as any).performSync();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Should still have the old snapshot
+      const retainedSnapshot = service.getCurrentSnapshot();
+      expect(retainedSnapshot).toEqual(firstSnapshot);
+      expect(service.getConsecutiveFailures()).toBe(1);
+    });
+
+    it('should reset consecutive failures on successful sync after failures', async () => {
+      // First failure
+      mockGraphQLClient.request.mockRejectedValueOnce(
+        new Error('Network error')
+      );
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(service.getConsecutiveFailures()).toBeGreaterThan(0);
+
+      // Successful sync
+      mockGraphQLClient.request.mockResolvedValueOnce(mockSuccessResponse);
+      await (service as any).performSync();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(service.getConsecutiveFailures()).toBe(0);
+    });
+
+    it('should handle 401 authentication errors', async () => {
+      const authError = new Error('Unauthorized');
+      (authError as any).response = { status: 401 };
+
+      mockGraphQLClient.request.mockRejectedValueOnce(authError);
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(service.getConsecutiveFailures()).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Module lifecycle', () => {
+    it('should start periodic sync on module init', async () => {
+      service = await createServiceWithConfig({
+        enabled: true,
+        interval_ms: 1000,
+      });
+
+      mockGraphQLClient.request.mockResolvedValue(mockSuccessResponse);
+      await service.onModuleInit();
+
+      // Initial sync should happen
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(mockGraphQLClient.request).toHaveBeenCalled();
+    });
+
+    it('should clean up interval on module destroy', async () => {
+      service = await createServiceWithConfig({ enabled: true });
+      mockGraphQLClient.request.mockResolvedValue(mockSuccessResponse);
+      await service.onModuleInit();
+
+      service.onModuleDestroy();
+
+      // After destroy, periodic sync should stop
+      const callCount = mockGraphQLClient.request.mock.calls.length;
+      await new Promise(resolve => setTimeout(resolve, 500));
+      // Call count should not increase significantly after destroy
+      expect(mockGraphQLClient.request.mock.calls.length).toBeLessThanOrEqual(
+        callCount + 1
+      );
+    });
+  });
+});

--- a/service/src/services/notification/blacklist-sync.service.ts
+++ b/service/src/services/notification/blacklist-sync.service.ts
@@ -1,0 +1,346 @@
+import {
+  Inject,
+  Injectable,
+  LoggerService,
+  OnModuleInit,
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ConfigService } from '@nestjs/config';
+import { GraphQLClient } from 'graphql-request';
+import { ConfigurationTypes, LogContext } from '@common/enums';
+import {
+  NotificationEmailBlacklistSnapshot,
+  BlacklistSyncConfig,
+} from '@src/types/blacklist.types';
+
+/**
+ * Service responsible for fetching and maintaining the notification email blacklist
+ * from the Alkemio GraphQL API. Implements periodic sync with exponential backoff
+ * on failures.
+ */
+@Injectable()
+export class BlacklistSyncService implements OnModuleInit {
+  private graphqlClient: GraphQLClient | null = null;
+  private currentSnapshot: NotificationEmailBlacklistSnapshot | null = null;
+  private lastErrorAt: Date | null = null;
+  private consecutiveFailures = 0;
+  private syncIntervalHandle: NodeJS.Timeout | null = null;
+  private config: BlacklistSyncConfig;
+
+  // GraphQL query for fetching the blacklist
+  private readonly BLACKLIST_QUERY = `
+    query BlacklistLookup {
+      platform {
+        id
+        settings {
+          integration {
+            notificationEmailBlacklist
+          }
+        }
+      }
+    }
+  `;
+
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+    private readonly configService: ConfigService
+  ) {
+    // Load configuration
+    const alkemioConfig = this.configService.get(ConfigurationTypes.ALKEMIO);
+    const blacklistSyncConfig = alkemioConfig?.blacklist_sync || {};
+
+    this.config = {
+      enabled: blacklistSyncConfig.enabled ?? true,
+      intervalMs: blacklistSyncConfig.interval_ms ?? 300000, // 5 minutes default
+      initialBackoffMs: blacklistSyncConfig.initial_backoff_ms ?? 250,
+      maxBackoffMs: blacklistSyncConfig.max_backoff_ms ?? 30000, // 30 seconds max
+    };
+
+    // Initialize GraphQL client if sync is enabled
+    if (this.config.enabled) {
+      const endpoint = alkemioConfig?.endpoint;
+      if (!endpoint) {
+        this.logger.error?.(
+          'GraphQL blacklist sync is enabled but ALKEMIO_SERVER_ENDPOINT is not configured. Sync will be disabled.',
+          LogContext.NOTIFICATIONS
+        );
+        this.config.enabled = false;
+      } else {
+        this.graphqlClient = new GraphQLClient(endpoint, {
+          headers: {},
+        });
+
+        this.logger.log?.(
+          `GraphQL blacklist sync initialized with interval: ${this.config.intervalMs}ms`,
+          LogContext.NOTIFICATIONS
+        );
+      }
+    } else {
+      this.logger.log?.(
+        'GraphQL blacklist sync is disabled. Using static configuration only.',
+        LogContext.NOTIFICATIONS
+      );
+    }
+  }
+
+  /**
+   * Lifecycle hook: Start the sync process when module initializes
+   */
+  async onModuleInit(): Promise<void> {
+    if (!this.config.enabled || !this.graphqlClient) {
+      return;
+    }
+
+    // Perform initial sync on startup
+    await this.performSync();
+
+    // Start periodic sync
+    this.startPeriodicSync();
+  }
+
+  /**
+   * Start the periodic sync interval
+   */
+  private startPeriodicSync(): void {
+    if (this.syncIntervalHandle) {
+      clearInterval(this.syncIntervalHandle);
+    }
+
+    this.syncIntervalHandle = setInterval(
+      () => this.performSync(),
+      this.config.intervalMs
+    );
+
+    this.logger.verbose?.(
+      `Periodic blacklist sync started with interval: ${this.config.intervalMs}ms`,
+      LogContext.NOTIFICATIONS
+    );
+  }
+
+  /**
+   * Perform a sync operation: fetch from GraphQL, normalize, and update snapshot
+   */
+  private async performSync(): Promise<void> {
+    if (!this.graphqlClient) {
+      return;
+    }
+
+    try {
+      this.logger.verbose?.(
+        'Starting blacklist sync from GraphQL...',
+        LogContext.NOTIFICATIONS
+      );
+
+      // Execute GraphQL query
+      const response = await this.graphqlClient.request<{
+        platform: {
+          id: string;
+          settings: {
+            integration: {
+              notificationEmailBlacklist: string[];
+            };
+          };
+        };
+      }>(this.BLACKLIST_QUERY);
+
+      // Extract blacklist array
+      const rawBlacklist =
+        response?.platform?.settings?.integration?.notificationEmailBlacklist ||
+        [];
+
+      // Normalize and validate entries
+      const normalizedEmails = this.normalizeAndValidate(rawBlacklist);
+
+      // Create new snapshot
+      const newSnapshot: NotificationEmailBlacklistSnapshot = {
+        emails: new Set(normalizedEmails),
+        fetchedAt: new Date(),
+        platformId: response?.platform?.id,
+      };
+
+      // Update current snapshot atomically
+      this.currentSnapshot = newSnapshot;
+
+      // Reset failure tracking on success
+      this.consecutiveFailures = 0;
+      this.lastErrorAt = null;
+
+      // Log success
+      // TODO: Add metric - notifications_blacklist_snapshot_age_seconds
+      // TODO: Add metric - notifications_blacklist_size (gauge)
+      this.logger.log?.(
+        JSON.stringify({
+          event: 'blacklist_sync_success',
+          snapshot_size: newSnapshot.emails.size,
+          fetched_at: newSnapshot.fetchedAt.toISOString(),
+          platform_id: newSnapshot.platformId,
+        }),
+        LogContext.NOTIFICATIONS
+      );
+
+      this.logger.verbose?.(
+        `Blacklist sync completed successfully. ${newSnapshot.emails.size} email(s) in blacklist.`,
+        LogContext.NOTIFICATIONS
+      );
+    } catch (error) {
+      this.handleSyncFailure(error);
+    }
+  }
+
+  /**
+   * Handle sync failure with exponential backoff
+   */
+  private handleSyncFailure(error: any): void {
+    this.consecutiveFailures++;
+    this.lastErrorAt = new Date();
+
+    const isAuthError = error?.response?.status === 401;
+    const errorType = isAuthError ? 'authentication_error' : 'sync_error';
+
+    // TODO: Add metric - notifications_blacklist_sync_failures_total (counter)
+    // TODO: Add metric - notifications_blacklist_snapshot_age_seconds (gauge)
+    this.logger.error?.(
+      JSON.stringify({
+        event: 'blacklist_sync_failure',
+        error_type: errorType,
+        consecutive_failures: this.consecutiveFailures,
+        error_message: error?.message || 'Unknown error',
+        last_snapshot_age_seconds: this.currentSnapshot
+          ? Math.floor(
+              (Date.now() - this.currentSnapshot.fetchedAt.getTime()) / 1000
+            )
+          : null,
+      }),
+      LogContext.NOTIFICATIONS
+    );
+
+    // Calculate backoff delay using exponential backoff
+    const backoffDelay = Math.min(
+      this.config.initialBackoffMs * Math.pow(2, this.consecutiveFailures - 1),
+      this.config.maxBackoffMs
+    );
+
+    this.logger.warn?.(
+      `Blacklist sync failed (attempt ${this.consecutiveFailures}). ` +
+        `${isAuthError ? 'Authentication error detected. ' : ''}` +
+        `Retrying in ${backoffDelay}ms. ` +
+        `${this.currentSnapshot ? 'Using last successful snapshot.' : 'No previous snapshot available.'}`,
+      LogContext.NOTIFICATIONS
+    );
+
+    // Schedule retry with backoff
+    if (this.consecutiveFailures === 1) {
+      // Only schedule immediate retry on first failure, then rely on periodic sync
+      setTimeout(() => this.performSync(), backoffDelay);
+    }
+  }
+
+  /**
+   * Normalize and validate email addresses from raw GraphQL response
+   */
+  private normalizeAndValidate(rawEmails: string[]): string[] {
+    const normalized: string[] = [];
+    const seen = new Set<string>();
+    const maxEntries = 250; // Platform limit
+
+    for (const rawEmail of rawEmails) {
+      if (typeof rawEmail !== 'string') {
+        this.logger.warn?.(
+          `Invalid blacklist entry (not a string): ${JSON.stringify(rawEmail)}. Skipping.`,
+          LogContext.NOTIFICATIONS
+        );
+        continue;
+      }
+
+      // Normalize: trim and lowercase
+      const email = rawEmail.trim().toLowerCase();
+
+      // Skip empty strings
+      if (email.length === 0) {
+        continue;
+      }
+
+      // Skip duplicates
+      if (seen.has(email)) {
+        continue;
+      }
+
+      // Validate email format (simple validation: has @ and . after @)
+      if (!this.isValidEmail(email)) {
+        this.logger.warn?.(
+          `Invalid email format in GraphQL blacklist: "${rawEmail}". Skipping.`,
+          LogContext.NOTIFICATIONS
+        );
+        continue;
+      }
+
+      seen.add(email);
+      normalized.push(email);
+
+      // Enforce limit
+      if (normalized.length >= maxEntries) {
+        this.logger.warn?.(
+          `GraphQL blacklist exceeds limit of ${maxEntries} entries. ` +
+            `Only the first ${maxEntries} valid entries will be used.`,
+          LogContext.NOTIFICATIONS
+        );
+        break;
+      }
+    }
+
+    if (normalized.length === 0 && rawEmails.length > 0) {
+      this.logger.warn?.(
+        `GraphQL returned ${rawEmails.length} blacklist entries, but none were valid after normalization.`,
+        LogContext.NOTIFICATIONS
+      );
+    }
+
+    return normalized;
+  }
+
+  /**
+   * Basic email validation: must contain @ and have a . after the @
+   */
+  private isValidEmail(email: string): boolean {
+    const atIndex = email.indexOf('@');
+    if (atIndex === -1 || atIndex === 0) {
+      return false;
+    }
+
+    const domainPart = email.substring(atIndex + 1);
+    return domainPart.includes('.') && domainPart.length > 2;
+  }
+
+  /**
+   * Get the current blacklist snapshot (thread-safe read)
+   * Returns null if no snapshot is available yet
+   */
+  public getCurrentSnapshot(): NotificationEmailBlacklistSnapshot | null {
+    return this.currentSnapshot;
+  }
+
+  /**
+   * Check if GraphQL sync is enabled
+   */
+  public isSyncEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Get the number of consecutive failures
+   */
+  public getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+
+  /**
+   * Cleanup on module destroy
+   */
+  onModuleDestroy(): void {
+    if (this.syncIntervalHandle) {
+      clearInterval(this.syncIntervalHandle);
+      this.syncIntervalHandle = null;
+    }
+  }
+}

--- a/service/src/services/notification/notifIcation.module.ts
+++ b/service/src/services/notification/notifIcation.module.ts
@@ -3,10 +3,12 @@ import { NotificationEmailPayloadBuilderService } from './notification.email.pay
 import { NotificationBlacklistService } from './notification.blacklist.service';
 import { NotificationService } from './notification.service';
 import { NotifmeModule } from '../notifme/notifme.module';
+import { BlacklistSyncService } from './blacklist-sync.service';
 
 @Module({
   imports: [NotifmeModule],
   providers: [
+    BlacklistSyncService,
     NotificationService,
     NotificationEmailPayloadBuilderService,
     NotificationBlacklistService,

--- a/service/src/types/blacklist.types.ts
+++ b/service/src/types/blacklist.types.ts
@@ -1,0 +1,49 @@
+/**
+ * Immutable snapshot of the notification email blacklist fetched from GraphQL
+ */
+export interface NotificationEmailBlacklistSnapshot {
+  /**
+   * Set of unique, normalized (lowercased, trimmed) email addresses
+   */
+  emails: Set<string>;
+
+  /**
+   * Timestamp when this snapshot was fetched from GraphQL
+   */
+  fetchedAt: Date;
+
+  /**
+   * Optional platform identifier (for future multi-platform support)
+   */
+  platformId?: string;
+
+  /**
+   * Optional version/ETag identifier (for future use)
+   */
+  sourceVersion?: string;
+}
+
+/**
+ * Configuration for GraphQL blacklist synchronization
+ */
+export interface BlacklistSyncConfig {
+  /**
+   * Whether GraphQL blacklist sync is enabled
+   */
+  enabled: boolean;
+
+  /**
+   * Interval between successful syncs (in milliseconds)
+   */
+  intervalMs: number;
+
+  /**
+   * Initial backoff delay for retry attempts (in milliseconds)
+   */
+  initialBackoffMs: number;
+
+  /**
+   * Maximum backoff delay for retry attempts (in milliseconds)
+   */
+  maxBackoffMs: number;
+}


### PR DESCRIPTION
This PR contains a single squashed commit with all code changes from #436 ("Implement GraphQL-sourced notification email blacklist with automatic sync"), based on the `002-graphql-blacklist` spec branch.

Key points:
- Dynamic GraphQL-sourced notification email blacklist with periodic sync
- Exponential backoff and last-good snapshot behavior on failures
- Integration into `NotificationBlacklistService` with static fallback
- New tests for sync behavior, normalization, and failure handling

Original multi-commit PR for reference: https://github.com/alkem-io/notifications/pull/436
