### PR TITLE
Fix the UTC issues & missing URLs in calendar event template

### DIFF
--- a/service/src/services/notification/notification.email.payload.builder.service.ts
+++ b/service/src/services/notification/notification.email.payload.builder.service.ts
@@ -257,7 +257,7 @@ export class NotificationEmailPayloadBuilderService {
     recipient: User
   ): SpaceCommunityCalendarEventCreatedEmailPayload {
     const dateFormatOptions: Intl.DateTimeFormatOptions = {
-      timeZone: 'UTC',
+      timeZone: 'Europe/Amsterdam',
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -269,14 +269,14 @@ export class NotificationEmailPayloadBuilderService {
     const startDate = new Date(eventPayload.calendarEvent.startDate);
     const endDate = new Date(eventPayload.calendarEvent.endDate);
 
-    const formattedStartDate = startDate.toLocaleString(
+    const formattedStartDate = `${startDate.toLocaleString(
       'en-GB',
       dateFormatOptions
-    );
+    )} (CET)`;
     const formattedEndDate =
       startDate.getTime() === endDate.getTime()
         ? null
-        : endDate.toLocaleString('en-GB', dateFormatOptions);
+        : `${endDate.toLocaleString('en-GB', dateFormatOptions)} (CET)`;
     return {
       ...this.createSpaceBaseEmailPayload(eventPayload, recipient),
       creator: {

--- a/service/test/services/notification/notification.email.payload.builder.calendar.event.spec.ts
+++ b/service/test/services/notification/notification.email.payload.builder.calendar.event.spec.ts
@@ -120,8 +120,11 @@ describe('NotificationEmailPayloadBuilderService', () => {
         );
 
       expect(result.calendarEvent.wholeDay).toBe(false);
-      expect(result.calendarEvent.formattedStartDate).toContain('10:15');
-      expect(result.calendarEvent.formattedEndDate).toContain('11:45');
+      // Times are displayed in CET (Europe/Amsterdam = UTC+1 in winter)
+      expect(result.calendarEvent.formattedStartDate).toContain('11:15');
+      expect(result.calendarEvent.formattedStartDate).toContain('(CET)');
+      expect(result.calendarEvent.formattedEndDate).toContain('12:45');
+      expect(result.calendarEvent.formattedEndDate).toContain('(CET)');
       expect(result.calendarEvent.location).toBe('Room 5');
       expect(result.calendarEvent.googleCalendarUrl).toBe(
         'https://calendar.google.com/event?eid=event-1'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar event email notifications now display event times in the Europe/Amsterdam timezone with explicit "(CET)" timezone indicator for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->