### PR TITLE
feat: handle the space-admin email-change notification event

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Library for interacting with Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts
+++ b/lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts
@@ -1,0 +1,17 @@
+import { NotificationEventPayloadSpace } from "../space/notification.event.payload.space";
+
+// Event USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION — published per qualifying
+// space via the server's buildBaseEventPayload. Extends
+// NotificationEventPayloadSpace, so it carries the full BaseEventPayload
+// envelope (including a server-resolved `recipients` array) plus the single
+// `space` the event concerns.
+export interface NotificationEventPayloadUserEmailChangeSpaceAdmin
+  extends NotificationEventPayloadSpace {
+  subjectProfileSummary: { id: string; displayName: string };
+  oldEmail: string;
+  newEmail: string;
+  initiatorProfileSummary?: { id: string; displayName: string };
+  initiatorRole: "self" | "platform_admin";
+  commitTimestampISO8601: string;
+  triggerOutcome: "COMMITTED" | "DRIFT_DETECTED";
+}

--- a/lib/src/dto/index.ts
+++ b/lib/src/dto/index.ts
@@ -14,5 +14,6 @@ export * from './platform/notification.event.payload.platform.space.created';
 export * from './email-change/notification.event.payload.user.email.change.security.signal';
 export * from './email-change/notification.event.payload.user.email.change.new.address';
 export * from './email-change/notification.event.payload.user.email.change.global.admin';
+export * from './email-change/notification.event.payload.user.email.change.space.admin';
 export * from './space';
 

--- a/service/package.json
+++ b/service/package.json
@@ -36,7 +36,7 @@
     "validate-connection": "ts-node src/utils/validate-connection.ts"
   },
   "dependencies": {
-    "@alkemio/notifications-lib": "0.15.0",
+    "@alkemio/notifications-lib": "0.16.0",
     "@nestjs/cli": "^11.0.7",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",

--- a/service/src/app.controller.ts
+++ b/service/src/app.controller.ts
@@ -34,6 +34,7 @@ import {
   NotificationEventPayloadUserEmailChangeSecuritySignal,
   NotificationEventPayloadUserEmailChangeNewAddress,
   NotificationEventPayloadUserEmailChangeGlobalAdmin,
+  NotificationEventPayloadUserEmailChangeSpaceAdmin,
 } from '@alkemio/notifications-lib';
 import { NotificationService } from './services/notification/notification.service';
 import { NotificationEvent } from './generated/alkemio-schema';
@@ -498,6 +499,18 @@ export class AppController {
   async sendUserEmailChangeGlobalAdminNotification(
     @Payload()
     eventPayload: NotificationEventPayloadUserEmailChangeGlobalAdmin,
+    @Ctx() context: RmqContext
+  ) {
+    return this.notificationService.processNotificationEvent(
+      eventPayload,
+      context
+    );
+  }
+
+  @EventPattern(NotificationEvent.UserEmailChangeSpaceAdminNotification)
+  async sendUserEmailChangeSpaceAdminNotification(
+    @Payload()
+    eventPayload: NotificationEventPayloadUserEmailChangeSpaceAdmin,
     @Ctx() context: RmqContext
   ) {
     return this.notificationService.processNotificationEvent(

--- a/service/src/email-templates/space.admin.user.email.change.js
+++ b/service/src/email-templates/space.admin.user.email.change.js
@@ -1,0 +1,27 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+var templates = require('./alkemio.template.blocks');
+/* eslint-disable quotes */
+module.exports = () => ({
+  name: 'space.admin.user.email.change',
+  title: '[{{space.displayName}}] Login email change: {{subjectName}}',
+  version: 1,
+  channels: {
+    email: {
+      to: '{{recipient.email}}',
+      subject:
+        '{{space.displayName}}: Login email change for {{subjectName}}',
+      html: `{% extends "src/email-templates/_layouts/email-transactional.html" %}
+        {% block content %}Hi{% if recipient.firstName %} {{recipient.firstName}}{% endif %},<br><br>
+        You're an admin or lead of the {{space.type}} <a style="color:#1d384a; text-decoration: none;" href="{{space.url}}">{{space.displayName}}</a>. The login email of <b>{{subjectName}}</b>, a member there, was changed on Alkemio.
+        <br><br>
+        User: {{subjectName}}<br>
+        Previous email: {{oldEmail}}<br>
+        New email: {{newEmail}}<br>
+        Changed on: {{changedAt}}<br>
+        Initiated by: {{initiatorName}}{% if isSelfInitiated %} (the user themselves){% else %} (a platform administrator){% endif %}
+        <br><br>
+        {% endblock %}
+        ${templates.footerBlock}`,
+    },
+  },
+});

--- a/service/src/generated/alkemio-schema.ts
+++ b/service/src/generated/alkemio-schema.ts
@@ -5110,6 +5110,7 @@ export enum NotificationEvent {
   UserEmailChangeGlobalAdminNotification = 'USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION',
   UserEmailChangeNewAddressNotification = 'USER_EMAIL_CHANGE_NEW_ADDRESS_NOTIFICATION',
   UserEmailChangeSecuritySignal = 'USER_EMAIL_CHANGE_SECURITY_SIGNAL',
+  UserEmailChangeSpaceAdminNotification = 'USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION',
   UserMentioned = 'USER_MENTIONED',
   UserMessage = 'USER_MESSAGE',
   UserMessageSender = 'USER_MESSAGE_SENDER',

--- a/service/src/services/notification/email-template-payload/index.ts
+++ b/service/src/services/notification/email-template-payload/index.ts
@@ -25,6 +25,7 @@ export * from './platform.global.role.change.email.payload';
 export * from './user.email.change.security.signal.email.payload';
 export * from './user.email.change.new.address.email.payload';
 export * from './platform.admin.user.email.change.email.payload';
+export * from './space.admin.user.email.change.email.payload';
 export * from './platform.forum.discussion.created.email.payload';
 export * from './platform.forum.discussion.comment.email.payload';
 export * from './organization.message.email.payload';

--- a/service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts
+++ b/service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts
@@ -1,0 +1,13 @@
+import { BaseSpaceEmailPayload } from './base.space.email.payload';
+
+// Email-template payload for the USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION
+// message sent to the admins and leads of a space. Space-scoped so the
+// message names the space it concerns (FR-005/FR-006).
+export interface SpaceAdminUserEmailChangeEmailPayload extends BaseSpaceEmailPayload {
+  subjectName: string;
+  initiatorName: string;
+  isSelfInitiated: boolean;
+  oldEmail: string;
+  newEmail: string;
+  changedAt: string;
+}

--- a/service/src/services/notification/notification.email.payload.builder.service.ts
+++ b/service/src/services/notification/notification.email.payload.builder.service.ts
@@ -36,6 +36,7 @@ import {
   UserEmailChangeSecuritySignalEmailPayload,
   UserEmailChangeNewAddressEmailPayload,
   PlatformAdminUserEmailChangeEmailPayload,
+  SpaceAdminUserEmailChangeEmailPayload,
 } from '@src/services/notification/email-template-payload';
 import {
   NotificationEventPayloadSpaceCommunityApplication,
@@ -66,6 +67,7 @@ import {
   NotificationEventPayloadUserEmailChangeSecuritySignal,
   NotificationEventPayloadUserEmailChangeNewAddress,
   NotificationEventPayloadUserEmailChangeGlobalAdmin,
+  NotificationEventPayloadUserEmailChangeSpaceAdmin,
 } from '@alkemio/notifications-lib';
 import { ConfigurationTypes } from '@src/common/enums/configuration.type';
 import { ConfigService } from '@nestjs/config';
@@ -398,6 +400,27 @@ export class NotificationEmailPayloadBuilderService {
         eventPayload.commitTimestampISO8601
       ),
       triggerOutcome: eventPayload.triggerOutcome,
+    };
+  }
+
+  public createEmailTemplatePayloadSpaceAdminUserEmailChange(
+    eventPayload: NotificationEventPayloadUserEmailChangeSpaceAdmin,
+    recipient: User
+  ): SpaceAdminUserEmailChangeEmailPayload {
+    return {
+      ...this.createSpaceBaseEmailPayload(eventPayload, recipient),
+      subjectName: eventPayload.subjectProfileSummary.displayName,
+      // Self-initiated changes omit initiatorProfileSummary — fall back to the
+      // subject's own profile for the initiator display (FR-006).
+      initiatorName:
+        eventPayload.initiatorProfileSummary?.displayName ??
+        eventPayload.subjectProfileSummary.displayName,
+      isSelfInitiated: eventPayload.initiatorRole === 'self',
+      oldEmail: eventPayload.oldEmail,
+      newEmail: eventPayload.newEmail,
+      changedAt: this.formatChangeTimestampUTC(
+        eventPayload.commitTimestampISO8601
+      ),
     };
   }
 

--- a/service/src/services/notification/notification.service.spec.ts
+++ b/service/src/services/notification/notification.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@test/mocks';
 import {
   NotificationEventPayloadSpaceCommunityApplication,
+  NotificationEventPayloadUserEmailChangeSpaceAdmin,
   BaseEventPayload,
 } from '@alkemio/notifications-lib';
 import { NotificationTemplateBuilder } from '@src/services/notifme';
@@ -584,6 +585,82 @@ describe('NotificationService', () => {
         false,
         false
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createEmailTemplatePayloadSpaceAdminUserEmailChange — builder unit coverage
+  // -------------------------------------------------------------------------
+
+  describe('createEmailTemplatePayloadSpaceAdminUserEmailChange', () => {
+    // The event-routing / processNotificationEvent suites spy on every builder
+    // method; restore originals so this suite exercises the real builder.
+    beforeEach(() => jest.restoreAllMocks());
+
+    const mkSpaceAdminEvent = (
+      overrides: Partial<NotificationEventPayloadUserEmailChangeSpaceAdmin> = {}
+    ): NotificationEventPayloadUserEmailChangeSpaceAdmin =>
+      ({
+        ...MINIMAL_BASE,
+        eventType: NotificationEvent.UserEmailChangeSpaceAdminNotification,
+        space: {
+          id: 's-1',
+          level: '0',
+          profile: {
+            displayName: 'Climate Space',
+            url: 'https://alkemio.dev/climate',
+          },
+          adminURL: 'https://alkemio.dev/climate/settings',
+        },
+        subjectProfileSummary: { id: 'u-subj', displayName: 'Sam Subject' },
+        oldEmail: 'old.address@example.com',
+        newEmail: 'new.address@example.com',
+        initiatorProfileSummary: { id: 'u-init', displayName: 'Ada Admin' },
+        initiatorRole: 'platform_admin',
+        commitTimestampISO8601: '2026-05-20T14:32:00.000Z',
+        triggerOutcome: 'COMMITTED',
+        ...overrides,
+      }) as NotificationEventPayloadUserEmailChangeSpaceAdmin;
+
+    const build = (
+      overrides?: Partial<NotificationEventPayloadUserEmailChangeSpaceAdmin>
+    ) =>
+      builderService.createEmailTemplatePayloadSpaceAdminUserEmailChange(
+        mkSpaceAdminEvent(overrides),
+        MINIMAL_RECIPIENT as any
+      );
+
+    it('passes the full old and new email addresses through unchanged', () => {
+      const payload = build();
+      expect(payload.oldEmail).toBe('old.address@example.com');
+      expect(payload.newEmail).toBe('new.address@example.com');
+    });
+
+    it('names the subject and the space the event concerns', () => {
+      const payload = build();
+      expect(payload.subjectName).toBe('Sam Subject');
+      expect(payload.space.displayName).toBe('Climate Space');
+      expect(payload.space.type).toBe('space');
+    });
+
+    it('uses the initiator display name and isSelfInitiated=false for an admin-initiated change', () => {
+      const payload = build();
+      expect(payload.isSelfInitiated).toBe(false);
+      expect(payload.initiatorName).toBe('Ada Admin');
+    });
+
+    it('falls back initiatorName to the subject and sets isSelfInitiated=true when self-initiated', () => {
+      const payload = build({
+        initiatorRole: 'self',
+        initiatorProfileSummary: undefined,
+      });
+      expect(payload.isSelfInitiated).toBe(true);
+      expect(payload.initiatorName).toBe('Sam Subject');
+    });
+
+    it('renders changedAt in UTC with an explicit UTC label', () => {
+      const payload = build();
+      expect(payload.changedAt).toBe('20 May 2026, 14:32 UTC');
     });
   });
 });

--- a/service/src/services/notification/notification.service.ts
+++ b/service/src/services/notification/notification.service.ts
@@ -34,6 +34,7 @@ import {
   NotificationEventPayloadUserEmailChangeSecuritySignal,
   NotificationEventPayloadUserEmailChangeNewAddress,
   NotificationEventPayloadUserEmailChangeGlobalAdmin,
+  NotificationEventPayloadUserEmailChangeSpaceAdmin,
 } from '@alkemio/notifications-lib';
 import { NotificationTemplateType } from '@src/types/notification.template.type';
 import { NotificationNoChannelsException } from '@src/common/exceptions';
@@ -496,6 +497,11 @@ export class NotificationService {
           eventPayload as NotificationEventPayloadUserEmailChangeGlobalAdmin,
           recipient
         );
+      case NotificationEvent.UserEmailChangeSpaceAdminNotification:
+        return this.notificationEmailPayloadBuilderService.createEmailTemplatePayloadSpaceAdminUserEmailChange(
+          eventPayload as NotificationEventPayloadUserEmailChangeSpaceAdmin,
+          recipient
+        );
       default:
         throw new EventPayloadNotProvidedException(
           `EmailPayload: Unable to recognize event:  ${eventPayload.eventType}`,
@@ -582,6 +588,8 @@ export class NotificationService {
         return 'user.email.change.new.address';
       case NotificationEvent.UserEmailChangeGlobalAdminNotification.valueOf():
         return 'platform.admin.user.email.change';
+      case NotificationEvent.UserEmailChangeSpaceAdminNotification.valueOf():
+        return 'space.admin.user.email.change';
       default:
         throw new EventPayloadNotProvidedException(
           `Email template: Unable to recognize event: ${event}`,

--- a/specs/005-space-admin-email-change/checklists/requirements.md
+++ b/specs/005-space-admin-email-change/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Space-Admin Email-Change Notification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The one open clarification (FR-007 — address-display posture)
+  was resolved during specification: space admins see the full old and new
+  addresses, consistent with the global-admin email-change notification.

--- a/specs/005-space-admin-email-change/contracts/events.md
+++ b/specs/005-space-admin-email-change/contracts/events.md
@@ -1,0 +1,92 @@
+# Event Contracts: Space-Admin Email-Change Notification
+
+**Branch**: `005-space-admin-email-change` | **Date**: 2026-05-20
+
+The notifications service exposes **no HTTP/GraphQL API** for this feature — it
+*consumes* one RabbitMQ event. This is the wire contract. Producer: the
+`alkemio-server` (`NotificationExternalAdapter`). Consumer: `alkemio-notifications`
+(`AppController` `@EventPattern` handler).
+
+Transport: the existing RabbitMQ notifications exchange. The **routing key** is
+the `NotificationEvent` value; the **message body** is the JSON payload below.
+
+---
+
+## Contract — `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`
+
+- **Direction**: server → notifications service
+- **Routing key**: `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` (research.md §R2)
+- **Envelope**: **`NotificationEventPayloadSpace`** (`BaseEventPayload` +
+  `space`) — published via the server's `buildBaseEventPayload`, the same shape
+  family as `SPACE_ADMIN_COMMUNITY_APPLICATION`
+- **Cardinality**: **one event per qualifying space**. If the subject is a
+  member of N spaces, the server publishes N events, each carrying one `space`
+  and that space's own resolved `recipients` (FR-005)
+- **Delivery target**: `recipients[]` — the server-resolved admin/lead set of
+  the carried `space`, with the change's subject excluded (FR-004) and opted-out
+  admins already filtered out (FR-009)
+
+```ts
+interface UserEmailChangeSpaceAdminNotificationPayload extends NotificationEventPayloadSpace {
+  // BaseEventPayload: eventType, triggeredBy, recipients: UserPayload[], platform
+  // NotificationEventPayloadSpace adds: space: SpacePayload
+  subjectProfileSummary: { id: string; displayName: string };
+  oldEmail: string;                // full
+  newEmail: string;                // full
+  initiatorProfileSummary?: { id: string; displayName: string };
+  initiatorRole: 'self' | 'platform_admin';
+  commitTimestampISO8601: string;  // ISO 8601 UTC
+  triggerOutcome: 'COMMITTED' | 'DRIFT_DETECTED';
+}
+```
+
+**Producer obligations**:
+
+- Emit **one event per space** of which the subject is a member — a plain
+  member, a lead, or an admin of the space all qualify equally (FR-002, FR-003).
+- Resolve `recipients` to that space's admin + lead role-holders, **excluding
+  the subject** (FR-004) and **excluding admins who opted out** of the new
+  preference (FR-009).
+- Populate `space` for the one space concerned (`id`, `level`, `profile`,
+  `adminURL`).
+- Publish only for the `COMMITTED` and `DRIFT_DETECTED` outcomes (FR-013).
+- `initiatorProfileSummary` is omitted when the change is self-initiated
+  (`initiatorRole === 'self'`).
+
+**Consumer obligations**:
+
+- Consume `recipients[]` as-is — **no** recipient resolution and **no** fan-out
+  in the service (research.md §R4).
+- Render one email per recipient naming the subject, the space, the initiator,
+  the full old and new addresses, and the UTC-formatted change time (FR-006,
+  FR-007, FR-008).
+- Render the **same routine message** for `COMMITTED` and `DRIFT_DETECTED` —
+  no drift variant (FR-014).
+- Apply the existing blacklist / unsubscribe filtering (FR-011) — automatic, via
+  `buildAndSendEmailNotifications`.
+
+---
+
+## Outcomes that produce NO event
+
+A drift-detected change has still **committed** the new email, so the contract
+fires for both `COMMITTED` and `DRIFT_DETECTED` — with the same routine message
+(FR-014). Rejected, rolled-back, drift-resolved and `*_failed` outcomes publish
+**nothing**; the notifications service therefore produces zero space-admin
+email-change emails for them (FR-013, SC-005). No consumer-side guard is
+required — absence of an event is the contract.
+
+A space whose only admin/lead is the subject produces an event with an **empty**
+`recipients` after exclusion — the service logs "No recipients" and acks without
+sending (spec edge case; existing `buildAndSendEmailNotifications` behaviour).
+
+---
+
+## Consumer routing summary
+
+| Routing key | `@EventPattern` handler | Normalization | Builder + template |
+|-------------|------------------------|---------------|--------------------|
+| `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` | new — thin pass-through | none (already `NotificationEventPayloadSpace`) | `createEmailTemplatePayloadSpaceAdminUserEmailChange` → `space.admin.user.email.change` |
+
+See [research.md §R4](./research.md) for the pass-through rationale and
+[data-model.md](./data-model.md) for the full field tables.

--- a/specs/005-space-admin-email-change/data-model.md
+++ b/specs/005-space-admin-email-change/data-model.md
@@ -1,0 +1,136 @@
+# Data Model: Space-Admin Email-Change Notification
+
+**Branch**: `005-space-admin-email-change` | **Date**: 2026-05-20
+**Inputs**: [spec.md](./spec.md), [research.md](./research.md)
+
+This feature has no persistent storage. The "data model" is the set of typed
+payloads that flow through two layers:
+
+1. **Wire payload** — published by the server, defined in `@alkemio/notifications-lib`.
+2. **Email-template payload** — consumed by the Nunjucks template.
+
+There is **no** normalized internal payload — unlike 004 events 1 & 2, this
+event arrives with the full `BaseEventPayload` envelope already in place
+(research.md §R4). The event is email-only this release (FR-012).
+
+---
+
+## 1. Wire payload — `@alkemio/notifications-lib`
+
+New type at `lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts`,
+exported from `lib/src/dto/index.ts`. Naming follows the existing
+`notification.event.payload.*.ts` convention and the 004 email-change family.
+
+### `NotificationEventPayloadUserEmailChangeSpaceAdmin`
+
+Event `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` (research.md §R2). **Extends
+`NotificationEventPayloadSpace`** — the shared space-notification payload —
+published via the server's `buildBaseEventPayload`, one event per qualifying
+space.
+
+Inherited from `NotificationEventPayloadSpace` (→ `BaseEventPayload`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `eventType` | `string` | `'USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION'`. |
+| `triggeredBy` | `UserPayload` | The initiating actor (server-populated). Required by `BaseEventPayload`; **not consumed** by this builder — initiator display uses `initiatorProfileSummary` instead (see §3). |
+| `recipients` | `UserPayload[]` | **Server-resolved**: the admins and leads of `space`, with the subject excluded and opted-out admins already filtered out (FR-002, FR-004, FR-009). The service delivers to this set as-is. |
+| `platform` | `{ url: string }` | Web client host — used by the shared footer block. |
+| `space` | `SpacePayload` | The **one** space this event concerns: `{ id, level, profile: { displayName, url }, adminURL }`. |
+
+Event-specific (mirrors the 004 global-admin email-change payload — research.md §R1):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `subjectProfileSummary` | `{ id: string; displayName: string }` | The user whose login email changed (the affected user). |
+| `oldEmail` | `string` | Full old address — space admins/leads are trusted recipients (FR-007). |
+| `newEmail` | `string` | Full new address (FR-007). |
+| `initiatorProfileSummary` | `{ id: string; displayName: string }` _(optional)_ | Absent for a self-initiated change; the builder falls back to `subjectProfileSummary` (FR-006 — "who initiated the change"). |
+| `initiatorRole` | `'self' \| 'platform_admin'` | Lowercase wire values (004 research §R3). Drives the self-initiation indicator. |
+| `commitTimestampISO8601` | `string` | ISO 8601 UTC instant of the change. |
+| `triggerOutcome` | `'COMMITTED' \| 'DRIFT_DETECTED'` | Uppercase wire values. Carried for parity with the global-admin event; **not consumed** — there is no drift variant (FR-014, research.md §R9). |
+
+> The 004 global-admin payload's `subjectMemberships` / `subjectGlobalRoles` are
+> **deliberately not declared** here — they were "informational only, not
+> consumed", and are irrelevant: the event already carries its single `space`
+> (research.md §R1).
+
+## 2. No normalization
+
+004 events 1 & 2 arrive raw and are reshaped by
+`NotificationService.normalizeRawEmailChangeEvent`. This event does **not** need
+that: extending `NotificationEventPayloadSpace` means the publisher emits
+`eventType`, `triggeredBy`, `recipients`, `platform`, and `space` directly. The
+`@EventPattern` handler forwards the payload unchanged to
+`processNotificationEvent` (research.md §R4).
+
+## 3. Email-template payload — `service/`
+
+New interface at
+`service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts`,
+exported from that folder's `index.ts`. Built by a new method on
+`NotificationEmailPayloadBuilderService`.
+
+### `SpaceAdminUserEmailChangeEmailPayload`
+
+Template `space.admin.user.email.change`. **Extends `BaseSpaceEmailPayload`**
+(research.md §R6).
+
+Inherited from `BaseSpaceEmailPayload`:
+
+| Field | Type | Derivation |
+|-------|------|-----------|
+| `platform.url` | `string` | Passthrough from `eventPayload.platform.url`. |
+| `recipient.firstName` | `string` | From the per-recipient `User`. |
+| `recipient.email` | `string` | From the per-recipient `User`. |
+| `recipient.notificationPreferences` | `string` | `…/settings/notifications` URL via `createUserNotificationPreferencesURL`. |
+| `space.displayName` | `string` | `eventPayload.space.profile.displayName`. |
+| `space.level` | `string` | `eventPayload.space.level`. |
+| `space.url` | `string` | `eventPayload.space.profile.url`. |
+| `space.type` | `string` | `'space'` if `level === '0'`, else `'subspace'`. |
+
+All eight inherited fields are produced by the existing `createSpaceBaseEmailPayload`
+helper — no new code.
+
+Event-specific:
+
+| Field | Type | Derivation |
+|-------|------|-----------|
+| `subjectName` | `string` | `subjectProfileSummary.displayName`. |
+| `initiatorName` | `string` | `initiatorProfileSummary?.displayName ?? subjectProfileSummary.displayName` (FR-006 fallback for self-initiated). |
+| `isSelfInitiated` | `boolean` | `initiatorRole === 'self'` — the template adds the explicit self-initiation indicator. |
+| `oldEmail` | `string` | Passthrough — full (FR-007). |
+| `newEmail` | `string` | Passthrough — full (FR-007). |
+| `changedAt` | `string` | `commitTimestampISO8601` formatted via `formatChangeTimestampUTC` — UTC, explicit label (FR-008, research.md §R8). |
+
+> `triggerOutcome` is **not** in the email-template payload — the message is the
+> same for committed and drift-detected outcomes (FR-014, research.md §R9).
+
+## 4. Validation rules
+
+- `initiatorRole` MUST be one of `'self'` / `'platform_admin'`; any other value
+  is a malformed event.
+- `triggerOutcome` MUST be `'COMMITTED'` / `'DRIFT_DETECTED'`. The server only
+  publishes this event for those two outcomes (FR-013); no consumer-side guard
+  is required — absence of an event is the contract for every other outcome.
+- `changedAt` MUST render in UTC with the `UTC` label and MUST NOT be a raw ISO
+  string (FR-008).
+- `recipients` is consumed exactly as received — the service adds no recipient
+  and resolves none. Correctness of FR-002/FR-004/FR-009 rests on the
+  server-resolved set (research.md §R4, §R7).
+- Each event carries exactly one `space`; the service does not aggregate or fan
+  out across spaces (FR-005).
+
+## 5. Event → builder → template map
+
+| Event | Builder method (`NotificationEmailPayloadBuilderService`) | Template file |
+|-------|----------------------------------------------------------|---------------|
+| `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` | `createEmailTemplatePayloadSpaceAdminUserEmailChange` | `space.admin.user.email.change.js` |
+
+## 6. Out of scope — the opt-out preference
+
+The new per-user opt-out preference (FR-009/FR-010) has **no representation in
+this repo**. The server stores it and resolves `recipients` with opted-out
+admins already excluded; the client surfaces the toggle. The notifications
+service models only what is on the wire — and the preference never reaches the
+wire as a distinct field (research.md §R7).

--- a/specs/005-space-admin-email-change/plan.md
+++ b/specs/005-space-admin-email-change/plan.md
@@ -1,0 +1,170 @@
+# Implementation Plan: Space-Admin Email-Change Notification
+
+**Branch**: `005-space-admin-email-change` | **Date**: 2026-05-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/005-space-admin-email-change/spec.md`
+
+## Summary
+
+When a user's login email is changed, the server publishes **one event per
+qualifying space** — every space that user is a member of (a plain member, a
+lead, or an admin of the space all qualify equally).
+Each event extends the shared space-notification payload (`NotificationEventPayloadSpace`),
+carries that one space, and carries a **server-resolved** `recipients` array (that
+space's admins and leads, with the subject excluded and opted-out admins already
+filtered out). The `alkemio-notifications` service does not yet recognise this
+event and would negative-ack it, so no email is delivered.
+
+This feature is a **sibling of the existing email-change family** (004 —
+security-signal, new-address, global-admin) but is **structurally modelled on the
+space-community notifications** (e.g. `SPACE_ADMIN_COMMUNITY_APPLICATION`): a
+per-space event extending `NotificationEventPayloadSpace`, not a single
+platform-wide fan-out. It adds one event payload type to
+`@alkemio/notifications-lib` and wires the service to handle it along the
+documented "add a notification" recipe: `@EventPattern` handler → payload builder
+→ Nunjucks template → email.
+
+**Technical approach** (from [research.md](./research.md)):
+
+- The event is published **with** the full `BaseEventPayload` envelope (it extends
+  `NotificationEventPayloadSpace`), so its `@EventPattern` handler is a **thin
+  pass-through** to `processNotificationEvent` — exactly like
+  `SpaceAdminCommunityApplication` and `UserEmailChangeGlobalAdminNotification`.
+  **No** raw-payload normalization is needed (unlike 004 events 1 & 2).
+- The notifications service neither resolves recipients nor fans out across spaces:
+  the server emits one event per space, each carrying its own resolved
+  `recipients`. The service handles each event independently.
+- The new opt-out preference (FR-009/FR-010) is **out of scope for this repo** —
+  the server filters recipients by the preference before publishing, and the
+  client surfaces the toggle. The notifications service consumes `recipients`
+  as-is. See [research.md §R7](./research.md).
+- One switch case each in `createEmailPayloadForEvent` and
+  `getEmailTemplateToUseForEvent`; one builder method; one template; one
+  `@EventPattern` handler; one `NotificationEvent` enum member.
+- The email-template payload extends `BaseSpaceEmailPayload` so the message names
+  the space (FR-005/FR-006); email-change fields mirror the global-admin sibling.
+- `initiatorRole` wire values are lowercase (`'self'` / `'platform_admin'`);
+  the change timestamp renders in UTC with an explicit label via the existing
+  `formatChangeTimestampUTC` helper. The template carries **no** drift variant —
+  committed and drift-detected use one routine message (FR-014).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 (`service/`), TypeScript 5.8 (`lib/`); Node.js 22.x (service, Volta-pinned 22.16.0), Node.js 20.x (lib)
+**Primary Dependencies**: NestJS 11, `@nestjs/microservices` (RabbitMQ / amqplib), notifme-sdk, Nunjucks, `@alkemio/notifications-lib`
+**Storage**: N/A — the service is a stateless RabbitMQ consumer; no persistence
+**Testing**: Jest (`service/`, `npm test`); `lib/` has no test runner — type-checked via `tsc --noEmit`
+**Target Platform**: Linux server, Docker container; RabbitMQ consumer microservice
+**Project Type**: Two-package monorepo — `lib/` (shared types) + `service/` (NestJS microservice)
+**Performance Goals**: N/A — email changes are low-frequency; per-space fan-out happens server-side and adds no new throughput/latency concern in this service
+**Constraints**: Email channel only this release (FR-012); additive library change, no breaking payload changes (FR-015); existing notification flows — including the three 004 email-change notifications — MUST NOT regress (FR-015 / SC-006)
+**Scale/Scope**: 1 event → 1 lib payload type, 1 service email-template payload, 1 Nunjucks template, 1 `@EventPattern` handler, 1 `NotificationEvent` enum member, 1 switch case × 2. Small, well-bounded; no new infrastructure. The preference (FR-009/FR-010) is upstream-only.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The project constitution (`.specify/memory/constitution.md`) is an unpopulated
+template — no principles, sections, or governance rules are ratified. There are
+therefore no constitutional gates to evaluate.
+
+- **Initial check (pre-Phase 0)**: PASS (vacuous — no gates defined).
+- **Post-design re-check (post-Phase 1)**: PASS — the design adds no new
+  projects, services, or infrastructure; it extends one existing library and one
+  existing service along their established patterns, and reuses the generic
+  send/ack/nack engine unchanged.
+
+No `/speckit.plan` ERROR condition is triggered: there are no gate violations and
+all NEEDS CLARIFICATION items are resolved in [research.md](./research.md).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-space-admin-email-change/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions R1–R10
+├── data-model.md        # Phase 1 — payload types (wire / email-template)
+├── quickstart.md        # Phase 1 — local validation (RabbitMQ + MailSlurper)
+├── contracts/
+│   └── events.md        # Phase 1 — the RabbitMQ event contract
+├── checklists/
+│   └── requirements.md  # pre-existing — spec quality checklist
+├── spec.md              # feature specification
+└── tasks.md             # Phase 2 — created by /speckit.tasks (NOT by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+lib/                                                 # @alkemio/notifications-lib
+├── src/dto/email-change/
+│   └── notification.event.payload.user.email.change.space.admin.ts   # NEW
+├── src/dto/index.ts                                                  # MODIFIED — export the new type
+└── package.json                                                      # MODIFIED — additive minor bump (0.15.0 → 0.16.0)
+
+service/                                             # alkemio-notifications
+├── src/app.controller.ts                                             # MODIFIED — 1 @EventPattern handler (thin pass-through)
+├── src/generated/alkemio-schema.ts                                   # MODIFIED — 1 NotificationEvent member
+├── src/services/notification/
+│   ├── notification.service.ts                                       # MODIFIED — 1 case in each of the two switches
+│   ├── notification.service.spec.ts                                  # MODIFIED — unit coverage for the new event
+│   ├── notification.email.payload.builder.service.ts                 # MODIFIED — 1 builder method
+│   └── email-template-payload/
+│       ├── space.admin.user.email.change.email.payload.ts            # NEW
+│       └── index.ts                                                  # MODIFIED — export the new payload
+├── src/email-templates/
+│   └── space.admin.user.email.change.js                              # NEW
+└── package.json                                                      # MODIFIED — bump @alkemio/notifications-lib dep (0.15.0 → 0.16.0)
+```
+
+**Structure Decision**: No new structure. The feature extends the existing
+two-package monorepo along its established conventions — the payload DTO joins
+the 004 family in `lib/src/dto/email-change/`; the email-template payload,
+template, builder method, switch cases, and `@EventPattern` handler land in
+`service/` exactly as for every other notification. The new lib type extends
+`NotificationEventPayloadSpace` (the shared space-notification payload), and the
+new email-template payload extends `BaseSpaceEmailPayload`, so the message is
+space-scoped (FR-005/FR-006). Because the event arrives with a full
+`BaseEventPayload` envelope and a server-resolved `recipients` array, the handler
+is a pass-through and the generic `buildAndSendEmailNotifications` engine is
+untouched — protecting the no-regression requirement (FR-015 / SC-006).
+
+## Complexity Tracking
+
+No constitutional violations (no ratified constitution). No new projects,
+services, abstractions, or infrastructure are introduced. The feature is a
+single notification added along the documented `CLAUDE.md` recipe; the per-space
+fan-out and recipient resolution are server-side, so this service gains no new
+control flow. Nothing to justify here.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _none_ | — | — |
+
+## Dependencies & sequencing notes
+
+- **Library before service**: the `@alkemio/notifications-lib` payload type and
+  version bump (0.15.0 → 0.16.0) must land first; the service then builds against
+  the new type and bumps its dependency in lockstep.
+- **Server publisher**: the server-side publisher is implemented (on the server's
+  `097-change-user-email` branch) — it publishes one
+  `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` event per space the subject is a
+  member of, with a server-resolved `recipients` array. End-to-end (Path B)
+  validation can run against it; the service-side handler, builder, template, and
+  unit tests are also validatable in isolation via direct RabbitMQ publish
+  (Path A — [quickstart.md](./quickstart.md)).
+- **`NotificationEvent` enum**: the one member was added manually (research.md
+  §R3). The wire value (FR-016) `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` is
+  **confirmed** — the server's `NotificationEvent` enum registers exactly that
+  literal. `npm run codegen` against the server can re-confirm it.
+- **Out-of-repo work**: the server-side publisher is implemented (on the server's
+  `097-change-user-email` branch) — it emits one event per space the subject is a
+  member of, resolves each space's admin/lead recipients filtered by the new
+  opt-out preference, and stores the preference. Still outstanding: the client
+  surfaces the toggle in the Space group of the notification-settings UI.
+
+## Next step
+
+Run `/speckit.tasks` to generate `tasks.md` — the dependency-ordered task
+breakdown — from this plan and the Phase 1 artifacts.

--- a/specs/005-space-admin-email-change/quickstart.md
+++ b/specs/005-space-admin-email-change/quickstart.md
@@ -1,0 +1,139 @@
+# Quickstart: Space-Admin Email-Change Notification
+
+**Branch**: `005-space-admin-email-change` | **Date**: 2026-05-20
+
+Local validation that the notifications service handles the
+`USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` event and delivers the right
+message. Two paths:
+
+- **Path A — direct RabbitMQ publish** (no server needed): validates the
+  notifications service in isolation.
+- **Path B — full end-to-end** (server running the publisher): validates the
+  real publish → per-space fan-out → deliver chain. The server-side publisher is
+  implemented (on the server's `097-change-user-email` branch), so Path B can be
+  run against a local stack built from that branch.
+
+## Prerequisites
+
+```bash
+# Build the library, then the service (monorepo: lib first)
+cd lib && npm install && npm run build
+cd ../service && npm install && npm run build
+
+# Start mailslurper (local SMTP sink)
+npm run start:services
+```
+
+- MailSlurper UI: `http://localhost:5051/mail`
+- RabbitMQ management: `http://localhost:15672` → queue `alkemio-notifications`
+- Run the service: `npm run start:dev`
+
+## Path A — direct RabbitMQ publish
+
+Publish a message to the `alkemio-notifications` queue with the **routing key**
+set to the event name and the **body** set to the JSON payload. (Use the
+RabbitMQ management UI "Publish message" panel, or any AMQP client.)
+
+### Scenario 1 — Member email change, admin-initiated (US1)
+
+Routing key: `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`
+
+```json
+{
+  "eventType": "USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION",
+  "triggeredBy": { "id": "u-init", "firstName": "Ada", "lastName": "Admin", "email": "ada@example.com", "type": "USER", "profile": { "displayName": "Ada Admin", "url": "" } },
+  "recipients": [
+    { "id": "u-a1", "firstName": "Bo", "lastName": "Admin", "email": "coadmin1@example.com", "type": "USER", "profile": { "displayName": "Bo Admin", "url": "http://localhost:3000/user/bo" } },
+    { "id": "u-a2", "firstName": "Cy", "lastName": "Lead", "email": "coadmin2@example.com", "type": "USER", "profile": { "displayName": "Cy Lead", "url": "http://localhost:3000/user/cy" } }
+  ],
+  "platform": { "url": "http://localhost:3000" },
+  "space": { "id": "s-1", "level": "0", "profile": { "displayName": "Climate Space", "url": "http://localhost:3000/climate" }, "adminURL": "http://localhost:3000/climate/settings" },
+  "subjectProfileSummary": { "id": "u-subj", "displayName": "Sam Subject" },
+  "oldEmail": "old.address@example.com",
+  "newEmail": "new.address@example.com",
+  "initiatorProfileSummary": { "id": "u-init", "displayName": "Ada Admin" },
+  "initiatorRole": "platform_admin",
+  "commitTimestampISO8601": "2026-05-20T14:32:00.000Z",
+  "triggerOutcome": "COMMITTED"
+}
+```
+
+**Expect**: one email per entry in `recipients` (`coadmin1@example.com` and
+`coadmin2@example.com`); each names the subject `Sam Subject`, the space
+`Climate Space`, the initiator `Ada Admin`, the full old and new addresses, and
+`20 May 2026, 14:32 UTC`. No "unsupported event" warning in the log (SC-001).
+
+### Scenario 2 — Self-initiated change
+
+Re-publish with `"initiatorRole": "self"` and `initiatorProfileSummary` omitted.
+
+**Expect**: the message shows the initiator as the subject's own display name
+(`Sam Subject`) with the explicit self-initiation indicator.
+
+### Scenario 3 — Drift-detected outcome
+
+Re-publish with `"triggerOutcome": "DRIFT_DETECTED"`.
+
+**Expect**: the email is delivered and reads **identically** to the `COMMITTED`
+message — there is no reconciliation-required variant (FR-014).
+
+### Scenario 4 — Subject is the space's only admin/lead (empty recipient set)
+
+Re-publish with `"recipients": []`.
+
+**Expect**: the service logs "No recipients found, aborting" and acks the
+message; zero emails sent; no error (spec edge case).
+
+### Scenario 5 — Blacklisted recipient (FR-011)
+
+Blacklist one recipient: add `coadmin1@example.com` to the `email.blacklist`
+notification-providers config setting (parsed by
+`notification.blacklist.service.ts`) and restart the service. Re-publish
+Scenario 1's message unchanged.
+
+**Expect**: `coadmin1@example.com` receives nothing — the service log records a
+blacklist filter for that address — while `coadmin2@example.com` still receives
+the email. Confirms the existing blacklist / unsubscribe filtering (the same
+`NotificationBlacklistService.filterRecipients` path) applies to the new event
+unchanged (FR-011); it runs inside `buildAndSendEmailNotifications`, so no
+feature code is involved.
+
+## Path B — full end-to-end (server publisher)
+
+Against a local stack with the server publisher running:
+
+1. Register a throwaway user; make it a member of three spaces (any mix of
+   member / lead / admin roles); note its Alkemio user id.
+2. As a platform admin, change that user's login email.
+3. Confirm the service log shows the event **handled** for each of the three
+   spaces — zero "unsupported event" warnings (SC-001).
+4. In MailSlurper: the admins and leads of each of the three spaces receive one
+   message naming the correct space; the subject receives none for this
+   notification (SC-002); the plain-membership space's admins/leads are notified
+   exactly like the others (SC-003).
+5. Confirm an admin who turned the new preference off receives nothing while
+   other admins of the same space still do (SC-004).
+
+> **Note**: Path B requires a local server stack built from the
+> `097-change-user-email` branch, where the publisher of
+> `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` is implemented. Path A remains the
+> quickest way to validate the notifications service in isolation.
+
+## Regression check
+
+Publish a `SPACE_ADMIN_COMMUNITY_APPLICATION` event (or exercise it via the
+server) and confirm it still delivers correctly; likewise publish a 004
+`USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION` event. The space-community and
+existing email-change flows must be unaffected (FR-015, SC-006).
+
+## Acceptance mapping
+
+| Check | Spec criterion |
+|-------|----------------|
+| No "unsupported event" log lines for the new event | SC-001 |
+| Every admin/lead of every space the subject is a member of (minus subject, minus opted-out) receives it | SC-002 |
+| A space's admins/leads are notified regardless of the subject's role in that space | SC-003 |
+| An admin who turned the new preference off receives zero such notifications | SC-004 |
+| Non-committed/drift outcomes produce zero such notifications | SC-005 |
+| The 004 email-change notifications and other flows still deliver | SC-006 |
+| A blacklisted recipient is filtered; other recipients still receive | FR-011 |

--- a/specs/005-space-admin-email-change/research.md
+++ b/specs/005-space-admin-email-change/research.md
@@ -1,0 +1,230 @@
+# Research: Space-Admin Email-Change Notification
+
+**Branch**: `005-space-admin-email-change` | **Date**: 2026-05-20
+**Spec**: [spec.md](./spec.md)
+**Upstream**: the sibling server/client specs for this feature; the existing
+email-change family ([specs/004-email-change-notifications](../004-email-change-notifications/)).
+
+This document resolves the unknowns in the Technical Context before design. It
+is grounded in a direct read of the current `notifications` codebase (May 2026)
+and the 004 email-change feature it extends.
+
+## Summary of decisions
+
+| # | Topic | Decision |
+|---|-------|----------|
+| R1 | Wire payload shape | Extends `NotificationEventPayloadSpace`; event-specific fields mirror the 004 global-admin email-change payload (`subjectProfileSummary`, `oldEmail`, `newEmail`, `initiatorProfileSummary?`, `initiatorRole`, `commitTimestampISO8601`, `triggerOutcome`) — minus the informational `subjectMemberships`/`subjectGlobalRoles` |
+| R2 | Event-name wire value (FR-016) | `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` — sibling of `USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION`. Confirmed: the server-side publisher registers exactly this literal |
+| R3 | `NotificationEvent` enum | Add one member `UserEmailChangeSpaceAdminNotification` to `service/src/generated/alkemio-schema.ts` |
+| R4 | Handler integration | Thin pass-through to `processNotificationEvent` — **no** normalization. The event carries the full `BaseEventPayload` envelope + a server-resolved `recipients` array |
+| R5 | lib payload placement | `lib/src/dto/email-change/` — joins the 004 email-change family |
+| R6 | Email-template payload base | Extends `BaseSpaceEmailPayload` so the message names the space (FR-005/FR-006) |
+| R7 | Opt-out preference (FR-009/FR-010) | **Out of scope for this repo** — the server filters recipients by the preference before publishing; the client surfaces the toggle |
+| R8 | Timestamp rendering | Reuse the existing `formatChangeTimestampUTC` helper — UTC, explicit label (FR-008) |
+| R9 | Drift-detected outcome | Single routine message, **no** template variant (FR-014). `triggerOutcome` is carried on the wire payload for parity but is not consumed |
+| R10 | Library versioning | Additive minor bump of `@alkemio/notifications-lib` (0.15.0 → 0.16.0) |
+
+---
+
+## R1 — Wire payload shape
+
+**Decision**: The new payload type `NotificationEventPayloadUserEmailChangeSpaceAdmin`
+**extends `NotificationEventPayloadSpace`** — the shared space-notification
+payload (`BaseEventPayload` + `space: SpacePayload`). On top of that envelope it
+carries the email-change-specific fields, mirroring the 004 global-admin
+sibling (`NotificationEventPayloadUserEmailChangeGlobalAdmin`):
+`subjectProfileSummary`, `oldEmail`, `newEmail`, `initiatorProfileSummary?`,
+`initiatorRole`, `commitTimestampISO8601`, `triggerOutcome`. Field-by-field
+detail is in [data-model.md](./data-model.md).
+
+**Rationale**: The spec is explicit (Key Entities, Assumptions): the publisher
+emits one event per qualifying space, each event extending the shared
+space-notification payload and carrying exactly one space — modelled on the
+space-community notifications (e.g. `SPACE_ADMIN_COMMUNITY_APPLICATION`), **not**
+on the global-admin email-change shape (one event, flat platform-wide
+recipients, a membership footprint). `NotificationEventPayloadSpace` is that
+shared payload; `NotificationEventPayloadSpaceCommunityApplication` is the
+precedent for extending it. The email-change *content* fields are identical in
+meaning to the global-admin notification, so they are reused verbatim for
+consistency across the email-change family.
+
+**Excluded**: `subjectMemberships` / `subjectGlobalRoles` from the global-admin
+payload — 004 carried them as "informational context only, not consumed". They
+are irrelevant here: the event already carries its single space, and the message
+body needs no membership footprint. Per YAGNI they are not declared.
+
+**Alternatives considered**: Mirroring the global-admin payload directly (one
+event, flat recipients) — rejected: the spec explicitly forbids that shape and
+requires per-space events so each message names its space (FR-005).
+
+## R2 — Event-name wire value (FR-016)
+
+**Decision**: The event name is **`USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`**,
+with enum member `UserEmailChangeSpaceAdminNotification`. The notifications
+service listens for exactly this string.
+
+**Rationale**: The 004 email-change family already establishes the
+`USER_EMAIL_CHANGE_<audience>_NOTIFICATION` naming —
+`USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION` for platform admins. The spec
+frames this feature as "a sibling of the existing email-change notifications",
+so the space-admin audience yields `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`.
+The `SPACE_ADMIN_*` family (e.g. `SPACE_ADMIN_COMMUNITY_APPLICATION`) names the
+*structural* model but not the wire value — naming follows the email-change
+family.
+
+**FR-016 obligation**: the value MUST match the publisher's wire value exactly.
+The authoritative source is the server's `NotificationEvent` enum
+(`server/src/common/enums/notification.event.ts`). The server-side publisher is
+now implemented (on the server's `097-change-user-email` branch) and that enum
+registers exactly `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`, so the literal is
+**confirmed**. `npm run codegen` against the server can re-confirm it. Were the
+literal ever to change, this single string is updated in the enum, the
+`@EventPattern`, and the two switch cases — the value is referenced through the
+`NotificationEvent` enum member, so the change is localised.
+
+## R3 — `NotificationEvent` enum
+
+**Decision**: Add one member to the `NotificationEvent` enum in
+`service/src/generated/alkemio-schema.ts`:
+`UserEmailChangeSpaceAdminNotification = 'USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION'`.
+
+**Rationale**: The enum already carries the three 004 members
+(`UserEmailChangeSecuritySignal`, `UserEmailChangeNewAddressNotification`,
+`UserEmailChangeGlobalAdminNotification`) and the `SPACE_ADMIN_*` members. The
+member was added manually; the value is fixed and known (R2) and matches the
+server publisher's `NotificationEvent` enum exactly. `npm run codegen` against
+the server can re-confirm it.
+
+**Note**: Codegen also picks up unrelated schema drift; if used, review the diff
+and keep it scoped to the one new member.
+
+## R4 — Handler integration: thin pass-through, no normalization
+
+**Decision**: The new `@EventPattern(NotificationEvent.UserEmailChangeSpaceAdminNotification)`
+handler in `app.controller.ts` is a **thin pass-through** — it forwards the
+payload straight to `processNotificationEvent`, exactly like
+`sendSpaceCommunityApplicationAdminNotification` and
+`sendUserEmailChangeGlobalAdminNotification`. There is **no** normalization step.
+
+**Rationale**: 004 events 1 & 2 (`USER_EMAIL_CHANGE_SECURITY_SIGNAL`,
+`USER_EMAIL_CHANGE_NEW_ADDRESS_NOTIFICATION`) are published *raw* and need
+`normalizeRawEmailChangeEvent` to inject the `BaseEventPayload` envelope. This
+event is different: it extends `NotificationEventPayloadSpace` → `BaseEventPayload`,
+so the publisher emits it with `eventType`, `triggeredBy`, `platform`, `space`,
+**and** a server-resolved `recipients` array already present. The existing
+pipeline (`processNotificationEvent` → `buildAndSendEmailNotifications` →
+blacklist filter → template lookup → send → ack/nack) then runs unchanged. This
+matches 004 event 3 (global-admin), whose handler is likewise a pass-through.
+
+**Consequence**: the notifications service performs **no** recipient resolution
+and **no** fan-out across spaces. The server emits one event per qualifying
+space; the service handles each independently. This satisfies FR-002, FR-004,
+and FR-005 entirely from the server-resolved `recipients` array — the
+service simply delivers to whoever is in it.
+
+**Alternatives considered**: A separate per-space processing path in the service
+— rejected: duplicates the ack/nack engine and contradicts the spec's explicit
+"the notifications service neither resolves recipients nor fans out across
+spaces" assumption.
+
+## R5 — Library payload placement
+
+**Decision**: The new payload type lives at
+`lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts`,
+exported from `lib/src/dto/index.ts`.
+
+**Rationale**: The spec frames the feature as "a sibling of the existing
+email-change notifications". The 004 feature created `lib/src/dto/email-change/`
+for exactly this family; grouping the new type there keeps the email-change
+family discoverable in one folder. The type imports `NotificationEventPayloadSpace`
+from `../space/notification.event.payload.space` — a cross-folder import that is
+already common in the DTO tree and carries no cost.
+
+**Alternatives considered**: Placing it under `lib/src/dto/space/` because it is
+structurally a space notification — rejected: feature-family grouping (the spec's
+own framing) wins over structural grouping for discoverability, and the 004
+folder already exists for this purpose.
+
+## R6 — Email-template payload base
+
+**Decision**: The new email-template payload `SpaceAdminUserEmailChangeEmailPayload`
+**extends `BaseSpaceEmailPayload`** (`BaseEmailPayload` + a `space` block).
+
+**Rationale**: FR-005/FR-006 require each message to name the space it concerns.
+`BaseSpaceEmailPayload` supplies `space: { displayName, level, url, type }`, and
+the existing `createSpaceBaseEmailPayload` builder helper populates it from
+`eventPayload.space`. The 004 global-admin email-template payload extended the
+plain `BaseEmailPayload` because it is platform-scoped; this feature is
+space-scoped, so it follows the space-community notifications
+(`CommunityApplicationCreatedEmailPayload extends BaseSpaceEmailPayload`) instead.
+The email-change content fields (`subjectName`, `initiatorName`,
+`isSelfInitiated`, `oldEmail`, `newEmail`, `changedAt`) mirror the global-admin
+email-template payload.
+
+## R7 — The opt-out preference (FR-009 / FR-010): out of scope for this repo
+
+**Decision**: The notifications service implements **no** preference logic. It
+consumes the `recipients` array on the event as-is. The new per-user opt-out
+preference is satisfied entirely upstream:
+
+- the **server** stores the preference, and resolves each space's admin/lead
+  recipient set *with opted-out admins already excluded* before publishing;
+- the **client** surfaces the toggle in the Space group of the
+  notification-settings UI.
+
+**Rationale**: This mirrors the 004 global-admin email-change event, whose
+recipient set is "server-resolved … filtered by the admin-notification setting"
+(004 research §R13). The notifications service has no authenticated GraphQL path
+to read per-user preferences — its only GraphQL call (the blacklist sync) is
+anonymous. The spec's own Assumptions confirm recipient resolution "does not
+happen in the notifications service". Therefore FR-009/FR-010 generate **no**
+tasks in this repo; they are tracked in the sibling server/client specs.
+
+**Impact**: `/speckit.tasks` MUST NOT emit notifications-service tasks for the
+preference. The only repo-side guarantee for FR-009 is the negative one: the
+service delivers to exactly the recipients it is given and adds nobody.
+
+## R8 — Timestamp rendering
+
+**Decision**: Render `commitTimestampISO8601` via the existing
+`NotificationEmailPayloadBuilderService.formatChangeTimestampUTC` helper — UTC,
+with an explicit `UTC` label, e.g. `20 May 2026, 14:32 UTC`.
+
+**Rationale**: FR-008 requires UTC, explicitly labelled, never a raw machine
+timestamp. The helper was added in 004 for precisely this and is already used by
+all three 004 email-change builders. Reuse it verbatim — no new formatting code.
+
+## R9 — Drift-detected outcome: one message, no variant
+
+**Decision**: The template renders a **single routine message** for both
+`COMMITTED` and `DRIFT_DETECTED` outcomes. There is **no** drift variant and
+**no** `triggerOutcome`-driven branching in the template or email-template
+payload. `triggerOutcome` is carried on the *wire* payload (R1) for parity with
+the global-admin event, but the service does not consume it.
+
+**Rationale**: FR-014 is explicit — a drift-detected outcome "MUST still produce
+this notification, using the same routine message as a clean commit — there is
+no separate reconciliation-required variant"; the reconciliation framing is
+reserved for platform staff (the global-admin notification) and is out of scope
+here. Contrast with 004's global-admin template, which *does* branch on
+`triggerOutcome`. Because the service produces the notification only when the
+server publishes the event, and the server publishes only for committed/
+drift-detected outcomes (FR-013), no consumer-side outcome guard is needed —
+absence of an event is the contract for every other outcome.
+
+## R10 — Library versioning
+
+**Decision**: Additive **minor** bump of `@alkemio/notifications-lib`, `0.15.0`
+→ `0.16.0`. One new payload type exported from `lib/src/dto/`; no existing type
+changes. The service `package.json` dependency is bumped to `0.16.0` in lockstep.
+
+**Rationale**: FR-015 — additive, no breaking changes. The repo is a two-package
+monorepo, so the library bump and the consuming service change land together
+(004 followed the same approach: `0.14.x` → `0.15.0`).
+
+## Blacklist / unsubscribe filtering
+
+**No change.** `NotificationBlacklistService.filterRecipients` keys on
+`recipient.email` and already runs inside `buildAndSendEmailNotifications`.
+Because this event flows through that method unchanged (R4), filtering applies
+automatically (FR-011) — no new code.

--- a/specs/005-space-admin-email-change/spec.md
+++ b/specs/005-space-admin-email-change/spec.md
@@ -1,0 +1,230 @@
+# Feature Specification: Space-Admin Email-Change Notification
+
+**Feature Branch**: `005-space-admin-email-change`
+**Created**: 2026-05-20
+**Status**: Ready for Implementation
+**Input**: User description: "Notify the admins and leads of each space a user belongs to when that user's login email is changed — a sibling of the existing email-change notifications, gated by a new opt-out toggle in the Space settings group."
+
+## Clarifications
+
+### Session 2026-05-20
+
+- Q: Should the publisher emit one event per qualifying space, or a single event carrying all spaces (so the notifications service fans out per space)? → A: One event per qualifying space, modelled on the existing space-community notifications (e.g. the community-application notification) rather than on the global-admin email-change notification — each event extends the shared space-notification payload, carrying that one space and a server-resolved recipient set of that space's admins/leads.
+
+### Session 2026-05-22
+
+- Q: Must the affected user hold an admin or lead role in a space for that space's administrators to be notified, or does a plain membership qualify? → A: A plain membership qualifies. The notification fires for every space the affected user is a member of — whether they are a plain member, a lead, or an admin of that space. Only the *recipient* must be a space admin or lead; the *subject*'s own role in the space is irrelevant.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Space admins learn that a member's login email changed (Priority: P1)
+
+When a user's login email is changed, the administrators and leads of every space
+that user belongs to are informed. The people who run a space are responsible for
+the community within it; when a member of that community has their login identity
+changed — especially by someone else — the space's admins and leads should find
+out, so an unexpected or unauthorized change to one of their members is noticed by
+people connected to that space rather than only by distant platform staff.
+
+**Why this priority**: This is the whole value of the feature. A space's admins
+and leads are the people closest to its members and the most likely to recognize
+that a change to a member's account is wrong. Without it, a change to a space
+member's login is visible only to platform-wide administrators. It delivers value
+on its own.
+
+**Independent Test**: Change the login email of a user who is a member of at
+least one space, and confirm the admins and leads of that space each receive a
+message naming the affected user, the space, who made the change, and when.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user who is a member of Space S, **When** that user's login email
+   is changed, **Then** every admin and lead of Space S receives one message
+   stating the user's login email was changed.
+2. **Given** the affected user is a member of several spaces, **When** the email
+   is changed, **Then** the admins and leads of each of those spaces are notified
+   and each message names the space it concerns.
+3. **Given** a space the affected user belongs to, **When** the change occurs,
+   **Then** the message names the affected user, the space, who initiated the
+   change, and when it happened.
+4. **Given** the affected user holds only a plain membership of Space S (no admin
+   or lead role), **When** the change occurs, **Then** the admins and leads of
+   Space S are still notified — a plain membership qualifies a space exactly as
+   an admin or lead role does.
+5. **Given** the affected user is themselves an admin or lead of a space, **When**
+   the change occurs, **Then** that user does not receive this notification for
+   their own change.
+
+---
+
+### User Story 2 - A space admin opts out of member email-change notifications (Priority: P2)
+
+A space administrator who does not want to be told about their members' email
+changes can turn the notification off in their personal notification settings,
+in the same Space group where they manage their other space-related preferences.
+
+**Why this priority**: Notification fatigue is real — an admin who runs busy
+spaces could receive a number of these. A single, discoverable opt-out keeps the
+feature from becoming noise. It is valuable, but the feature delivers its core
+worth (User Story 1) without it.
+
+**Independent Test**: As a space admin, turn the new preference off, then trigger
+an email change for a member of a space they administer, and confirm no message
+is delivered to the opted-out admin while other admins still receive it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a space admin who has left the new preference on (default), **When**
+   a member's email is changed, **Then** they receive the notification.
+2. **Given** a space admin who has turned the new preference off, **When** a
+   member's email is changed, **Then** they do not receive the notification, and
+   other admins are unaffected.
+3. **Given** the notification-settings screen, **When** a space admin views the
+   Space group, **Then** the new preference appears there as a labelled toggle
+   alongside the other space notifications.
+
+---
+
+### Edge Cases
+
+- **Affected user is a member of no spaces**: this notification produces nothing
+  — the security-signal, new-address, and global-admin email-change notifications
+  still fire as before.
+- **A space whose only admin/lead is the affected user**: after excluding the
+  subject there is no admin or lead left to notify for that space, so no
+  notification is produced for it.
+- **A space admin is also the initiator of the change**: they still receive the
+  notification (not suppressed) unless they have opted out — only the *subject*
+  of the change is excluded.
+- **Self-initiated change**: the message reflects that the user changed it
+  themselves rather than an administrator doing it on their behalf.
+- **Drift-detected outcome**: the email change still committed, so the
+  notification is still sent; it carries the same routine message — the
+  reconciliation-required framing is reserved for platform staff and is out of
+  scope here.
+- **Failed / rejected / rolled-back change**: no email-change events are
+  published, so no space-admin notification is produced.
+- **Recipient on blacklist / unsubscribed**: existing blacklist and unsubscribe
+  filtering applies unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The notifications service MUST recognize and successfully handle a
+  new space-admin email-change event so that it is not treated as an unsupported
+  event.
+- **FR-002**: The system MUST deliver the notification to the administrators
+  (admin and lead roles) of every space of which the affected user is a member,
+  regardless of the role the affected user holds in that space.
+- **FR-003**: The affected user's own role in a space MUST NOT affect whether
+  that space's administrators are notified — a plain membership qualifies a space
+  exactly as an admin or lead role does.
+- **FR-004**: The system MUST exclude the affected user (the subject of the
+  change) from receiving this notification, even where the subject is themselves
+  an admin or lead of the space.
+- **FR-005**: The system MUST send one message per space the affected user is a
+  member of, and each message MUST identify the space it concerns.
+- **FR-006**: Each message MUST state that the user's login email was changed,
+  and MUST show the affected user's name, the space concerned, who initiated the
+  change (the user themselves vs. an administrator), and the change time.
+- **FR-007**: The message MUST show the affected user's full old and new email
+  addresses, consistent with how the platform global-admin email-change
+  notification presents them — the recipients are the administrators and leads
+  of a space the affected user belongs to and are trusted with that detail.
+- **FR-008**: The change time MUST be rendered in UTC, explicitly labelled as
+  UTC, and MUST NOT be shown as a raw machine timestamp.
+- **FR-009**: The notification MUST be gated by a new per-user notification
+  preference, presented in the Space group of the notification settings;
+  administrators who have turned this preference off MUST NOT receive it.
+- **FR-010**: The new preference's default state MUST be consistent with the
+  existing global-admin email-change notification preference.
+- **FR-011**: All messages MUST respect the existing blacklist and unsubscribe
+  filtering already applied to other notifications.
+- **FR-012**: The notification MUST be delivered over email only in this
+  release; no in-app or push channel is required.
+- **FR-013**: The system MUST produce this notification only for committed or
+  drift-detected change outcomes, and MUST NOT produce it for any other outcome.
+- **FR-014**: A drift-detected outcome MUST still produce this notification,
+  using the same routine message as a clean commit — there is no separate
+  reconciliation-required variant.
+- **FR-015**: Existing notification flows — including the three existing
+  email-change notifications (security-signal, new-address, global-admin) — MUST
+  continue to function unchanged.
+- **FR-016**: The event-name value the service listens for MUST match the
+  publisher's wire value exactly.
+
+### Key Entities *(include if feature involves data)*
+
+- **Space-admin email-change notification**: One per-space message sent to a
+  space's administrators. The publisher emits one event per space the affected
+  user is a member of, modelled on the existing space-community notifications
+  (e.g. the community-application notification) — each event extends the shared
+  space-notification payload and carries exactly one space — not on the
+  global-admin email-change notification. Attributes: the affected user, the one
+  space concerned, the initiator, the change time, the change outcome.
+- **Recipient set (per space)**: The admins and leads of the single space carried
+  on the event — a space of which the subject is a member — with the subject
+  excluded. Resolved by the publisher and carried on the event as its flat
+  recipient set; the notifications service neither resolves recipients nor fans
+  out across spaces.
+- **Space-admin email-change preference**: The new per-user opt-out toggle, shown
+  in the Space group of the notification-settings UI.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After an email change, the notifications service produces zero
+  "unsupported event" log entries for the new space-admin email-change event.
+- **SC-002**: 100% of the admins and leads of every space the subject is a
+  member of — excluding the subject and anyone who has opted out — receive the
+  notification.
+- **SC-003**: A space's admins and leads are notified of a member's email change
+  regardless of that member's role in the space — a plain member, a lead, and an
+  admin all trigger the notification identically.
+- **SC-004**: An administrator who has turned the new preference off receives
+  zero such notifications.
+- **SC-005**: Change outcomes other than committed or drift-detected produce
+  zero such notifications.
+- **SC-006**: The three existing email-change notifications and all other
+  notification flows continue to deliver correctly after this feature ships
+  (no regression).
+
+## Assumptions
+
+- The server (the email-change publisher) will be extended to publish one event
+  per space the subject is a member of, each carrying a server-resolved recipient
+  set for that space — recipient resolution does not happen in the notifications
+  service. This mirrors the existing space-community notifications (e.g. the
+  community-application notification): each event extends the shared
+  space-notification payload, carrying a single space and that space's recipient
+  set. It does NOT follow the global-admin email-change shape (one event, a flat
+  platform-wide recipient set, a membership footprint).
+- The server resolves which spaces qualify — every space the subject is a member
+  of — and emits one event per such space; the notifications service neither
+  derives qualifying spaces nor fans out across them, handling each per-space
+  event independently.
+- "Space administrator" (the recipient role) refers to the space admin and space
+  lead roles. The affected user (the subject) qualifies a space by a membership
+  of any kind — a plain member, a lead, or an admin of that space — their role
+  there does not matter.
+- The new preference defaults to on (an opt-out model), consistent with the
+  global-admin email-change preference.
+- English is the only language required; email is the only channel this release.
+- The notification fires for both committed and drift-detected outcomes with a
+  single routine message; the drift reconciliation workflow remains with
+  platform staff and is out of scope.
+- The new preference is shown in the Space group of the notification-settings
+  UI as an administrator-level toggle, alongside the existing space
+  notifications.
+
+## Dependencies
+
+- Server-side work to publish one event per space the subject is a member of,
+  resolve each space's administrator (admin/lead) recipients, and store the new
+  notification preference.
+- Client-side work to surface the new preference toggle in the
+  notification-settings UI.
+- The existing email-change notification family (the three notifications already
+  delivered) — this feature is a sibling addition to that family.

--- a/specs/005-space-admin-email-change/tasks.md
+++ b/specs/005-space-admin-email-change/tasks.md
@@ -1,0 +1,258 @@
+---
+description: "Task list for Space-Admin Email-Change Notification"
+---
+
+# Tasks: Space-Admin Email-Change Notification
+
+**Input**: Design documents from `/specs/005-space-admin-email-change/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/events.md, quickstart.md
+
+**Tests**: One targeted unit-coverage task (T013) is included because plan.md's
+"Project Structure" explicitly lists `notification.service.spec.ts` as MODIFIED
+for "unit coverage for the new event". It is targeted coverage of the new
+builder method — **not** a TDD-first approach. The feature specification
+requests no broader automated tests; the remaining validation is the quickstart
+Path A checks (T014) plus a regression pass over the existing Jest suite (T017).
+
+**Organization**: Tasks are grouped by user story so each story can be
+implemented, validated, and delivered as an independent increment.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different file, no dependency on an incomplete task)
+- **[Story]**: `[US1]` / `[US2]` — maps the task to a user story
+- Every task names the exact file path it touches
+
+## Path Conventions
+
+Two-package monorepo (plan.md "Project Structure"):
+
+- `lib/` — `@alkemio/notifications-lib` (shared wire payload types)
+- `service/` — `alkemio-notifications` NestJS RabbitMQ consumer
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Capture the pre-change baseline.
+
+- [X] T001 Establish the no-regression baseline: run `npm run build` in `lib/`, then `npm run build` and `npm test` in `service/`, and confirm all succeed on a clean `005-space-admin-email-change` checkout before any changes (baseline evidence for FR-015 / SC-006). No directory scaffolding is needed — `lib/src/dto/email-change/` already exists from the 004 feature.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The `@alkemio/notifications-lib` data contract, the library version
+bump, and the `NotificationEvent` enum member — the shared changes every
+service-side task depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Create the wire payload type `NotificationEventPayloadUserEmailChangeSpaceAdmin` in `lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts` — **extends `NotificationEventPayloadSpace`** (import from `../space/notification.event.payload.space`). Event-specific fields: `subjectProfileSummary: { id: string; displayName: string }`, `oldEmail: string`, `newEmail: string`, `initiatorProfileSummary?: { id: string; displayName: string }`, `initiatorRole: 'self' | 'platform_admin'`, `commitTimestampISO8601: string`, `triggerOutcome: 'COMMITTED' | 'DRIFT_DETECTED'` (data-model.md §1, research.md §R1). Do NOT declare `subjectMemberships` / `subjectGlobalRoles` — deliberately excluded (research.md §R1).
+- [X] T003 Export the new type from `lib/src/dto/index.ts` — add `export * from './email-change/notification.event.payload.user.email.change.space.admin';` alongside the existing three email-change exports. Depends on T002.
+- [X] T004 [P] Bump `version` in `lib/package.json` from `0.15.0` to `0.16.0` — additive minor bump, one new payload type, no existing type changes (research.md §R10, FR-015).
+- [X] T005 [P] Add one member to the `NotificationEvent` enum in `service/src/generated/alkemio-schema.ts`: `UserEmailChangeSpaceAdminNotification = 'USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION'` (research.md §R2/§R3). The wire value MUST match the publisher exactly (FR-016). The server-side publisher is now implemented (on the server's `097-change-user-email` branch) and registers exactly `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` in its `NotificationEvent` enum, so the literal is **confirmed**. The member was added manually; `npm run codegen` against the server can re-confirm it (review the diff and keep it scoped to this one member).
+- [X] T006 Make `@alkemio/notifications-lib@0.16.0` resolvable to `service/`: set the `@alkemio/notifications-lib` dependency in `service/package.json` from `0.15.0` to `0.16.0`, run `npm run build` in `lib/`, then make `0.16.0` resolvable to `service/` (`npm pack` in `lib/` + install the tarball into `service/`, or `npm link`) — `service/` consumes the library as a versioned dependency, not a workspace link. Depends on T002, T003, T004.
+
+**Checkpoint**: The library data contract (`@alkemio/notifications-lib@0.16.0`) and the `NotificationEvent` enum member are in place and resolvable to `service/` — the service-side notification wiring (User Story 1) can now begin.
+
+---
+
+## Phase 3: User Story 1 - Space admins learn that a member's login email changed (Priority: P1) 🎯 MVP
+
+**Goal**: When a user's login email changes, the admins and leads of every space
+that user is a member of receive one email per space — naming the affected
+user, the space, who initiated the change (self vs. a platform
+administrator), the full old and new addresses, and the UTC change time. The
+notifications service handles the new `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`
+event as a thin pass-through, delivering to the server-resolved `recipients`
+array as-is — no recipient resolution and no fan-out in this service.
+
+**Independent Test**: Publish a `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION`
+event (quickstart.md Path A Scenario 1) and confirm one email per `recipients`
+entry, each naming the subject, the space, the initiator, the full old and new
+addresses, and the UTC-formatted change time — with no "unsupported event" log
+line.
+
+### Implementation for User Story 1
+
+- [X] T007 [P] [US1] Create the email-template payload interface `SpaceAdminUserEmailChangeEmailPayload` **extending `BaseSpaceEmailPayload`** in `service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts` (import `BaseSpaceEmailPayload` from `./base.space.email.payload`). Event-specific fields: `subjectName: string`, `initiatorName: string`, `isSelfInitiated: boolean`, `oldEmail: string`, `newEmail: string`, `changedAt: string` (data-model.md §3). Do NOT include `triggerOutcome` — the message is identical for committed and drift-detected outcomes (FR-014, research.md §R9).
+- [X] T008 [US1] Export `SpaceAdminUserEmailChangeEmailPayload` from `service/src/services/notification/email-template-payload/index.ts`. Depends on T007.
+- [X] T009 [US1] Add builder method `createEmailTemplatePayloadSpaceAdminUserEmailChange(eventPayload, recipient)` to `service/src/services/notification/notification.email.payload.builder.service.ts`, typing `eventPayload` as `NotificationEventPayloadUserEmailChangeSpaceAdmin`. Populate the inherited `BaseSpaceEmailPayload` fields via the existing `createSpaceBaseEmailPayload` helper; set `subjectName` from `subjectProfileSummary.displayName`, `initiatorName` from `initiatorProfileSummary?.displayName ?? subjectProfileSummary.displayName` (FR-006 self-initiated fallback), `isSelfInitiated` from `initiatorRole === 'self'`; format `commitTimestampISO8601` into `changedAt` via the existing `formatChangeTimestampUTC` helper (UTC, explicit "UTC" label — FR-008, research.md §R8); pass `oldEmail` and `newEmail` through verbatim — full addresses (FR-007). Depends on T002, T007.
+- [X] T010 [P] [US1] Create the Nunjucks email template `service/src/email-templates/space.admin.user.email.change.js` — states the named user's login email was changed and names the `space` it concerns; shows `subjectName`, the `space` block (displayName / url), `initiatorName`, the full `oldEmail` and `newEmail`, and `changedAt`; when `isSelfInitiated` is true renders the explicit self-initiation indicator ("changed it themselves" vs. "changed by a platform administrator" — FR-006). One routine message only — NO `triggerOutcome` branch and NO reconciliation-required variant (FR-014, research.md §R9). Follow an existing space-scoped template such as `service/src/email-templates/user.space.community.application.submitted.js` for the space/header/footer blocks and `service/src/email-templates/platform.admin.user.email.change.js` for the email-change content.
+- [X] T011 [P] [US1] Add the `@EventPattern(NotificationEvent.UserEmailChangeSpaceAdminNotification)` handler `sendUserEmailChangeSpaceAdminNotification` to `service/src/app.controller.ts` — a thin pass-through that delegates the `NotificationEventPayloadUserEmailChangeSpaceAdmin` payload straight to `notificationService.processNotificationEvent(eventPayload, context)` with NO normalization (the payload already carries the full `BaseEventPayload` envelope + a server-resolved `recipients` array), mirroring the existing `sendUserEmailChangeGlobalAdminNotification` handler. Add the import for `NotificationEventPayloadUserEmailChangeSpaceAdmin` from `@alkemio/notifications-lib`. Depends on T002, T005.
+- [X] T012 [US1] Add the space-admin cases to the two switch statements in `service/src/services/notification/notification.service.ts`: in `createEmailPayloadForEvent` add `case NotificationEvent.UserEmailChangeSpaceAdminNotification:` returning the T009 builder call (`eventPayload as NotificationEventPayloadUserEmailChangeSpaceAdmin`, `recipient`); in `getEmailTemplateToUseForEvent` add `case NotificationEvent.UserEmailChangeSpaceAdminNotification.valueOf():` returning `'space.admin.user.email.change'` (the T010 template filename, without the `.js` extension). Depends on T009, T010.
+- [X] T013 [US1] Add targeted unit coverage for the new event to `service/src/services/notification/notification.service.spec.ts` — the data-driven `event routing — all NotificationEvent types` suite already exercises routing once T005 + T012 land; add explicit assertions for the new builder method `createEmailTemplatePayloadSpaceAdminUserEmailChange`: the self-initiated `initiatorName` fallback to `subjectProfileSummary.displayName`, the `isSelfInitiated` derivation from `initiatorRole`, the `formatChangeTimestampUTC` rendering of `changedAt`, and that `oldEmail` / `newEmail` pass through in full. Depends on T009–T012.
+- [ ] T014 [US1] Validate User Story 1 — with `lib/` built and `0.16.0` resolvable to `service/` (T006), build `service/`, start MailSlurper (`npm run start:services`) and the service (`npm run start:dev`), then run quickstart.md Path A Scenarios 1–3 by publishing `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` messages: Scenario 1 (admin-initiated) → one email per `recipients` entry naming the subject, space, initiator, full old/new addresses and `20 May 2026, 14:32 UTC`, with no "unsupported event" log line (SC-001); Scenario 2 (`initiatorRole: 'self'`, `initiatorProfileSummary` omitted) → the initiator shows the subject's own display name with the self-initiation indicator; Scenario 3 (`triggerOutcome: 'DRIFT_DETECTED'`) → the email reads identically to the `COMMITTED` message (FR-014). End-to-end Path B can now be exercised against the implemented server publisher (plan.md "Dependencies"); Path A remains the quickest isolated check.
+
+**Checkpoint**: User Story 1 is fully functional and independently testable — the complete value of the feature is delivered.
+
+---
+
+## Phase 4: User Story 2 - A space admin opts out of member email-change notifications (Priority: P2)
+
+**Goal**: A space administrator can turn this notification off in the Space group
+of their notification settings.
+
+**⚠️ Out of scope for this repository.** Per research.md §R7, the opt-out
+preference (FR-009 / FR-010) is satisfied entirely upstream: the **server**
+stores the preference and resolves each space's `recipients` with opted-out
+admins already excluded; the **client** surfaces the toggle. The notifications
+service implements **no** preference logic — it consumes the `recipients` array
+as-is. `/speckit.tasks` therefore emits **no implementation tasks** for the
+preference in this repo; they are tracked in the sibling server/client specs.
+The only repo-side obligation is the negative guarantee verified below.
+
+**Independent Test**: Publish the event for the same space twice, differing only
+in whether a given admin address is present in `recipients`, and confirm the
+service delivers to exactly the listed addresses and adds nobody.
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Verify the consumer-side negative guarantee for FR-009 — with the service running, publish two `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` messages for the same space differing only in `recipients`: one including a given admin address, one omitting it (simulating that admin having opted out server-side). Confirm the service delivers exactly to the addresses in `recipients` and adds nobody — the omitted admin receives nothing while the others still do (SC-004) — and that the empty-`recipients` case (quickstart.md Path A Scenario 4) logs "No recipients" and acks without sending. No code change is expected: the pass-through handler (T011) and `buildAndSendEmailNotifications` already deliver to `recipients` as-is. Depends on T014.
+
+**Checkpoint**: The notifications service provably delivers to exactly the server-resolved recipient set — opted-out admins, filtered out upstream, never receive the email.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Static checks and the no-regression guarantee.
+
+- [X] T016 [P] Run `npm run lint` in `service/` (`tsc --noEmit && eslint`) and `tsc --noEmit` in `lib/`; resolve any type or lint errors introduced by the feature (`lib/` has no `eslint.config.js` — rely on `tsc --noEmit`, per CLAUDE.md "Known Issues").
+- [X] T017 [P] Run `npm test` in `service/` and confirm the full Jest suite passes — including the data-driven `event routing — all NotificationEvent types` test now covering `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` — with no regression to existing notification flows (FR-015 / SC-006).
+- [ ] T018 Regression check — publish a `SPACE_ADMIN_COMMUNITY_APPLICATION` event and a `USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION` event (quickstart.md "Regression check") and confirm both still render and deliver correctly; the space-community flow and the existing 004 email-change flows MUST be unaffected (FR-015 / SC-006).
+- [ ] T019 Full acceptance pass — walk quickstart.md's "Acceptance mapping" table and confirm SC-001 (no "unsupported event" log lines), SC-002 (every listed recipient receives it), SC-003 (a space's admins/leads are notified regardless of the subject's role in that space), SC-005 (non-committed/drift outcomes produce no event — verified by absence), SC-004 (opted-out admins, via T015), FR-011 (blacklist / unsubscribe filtering — quickstart.md Path A Scenario 5: a blacklisted recipient is filtered while other recipients still receive), and SC-006 (no regression). End-to-end Path B can now be run against the implemented server publisher.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: after Setup. **Blocks all user story work.**
+- **User Story 1 (Phase 3)**: after Foundational.
+- **User Story 2 (Phase 4)**: no implementation in this repo; its single
+  verification task (T015) depends on User Story 1 being delivered (T014).
+- **Polish (Phase 5)**: after User Story 1 is complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after Foundational. Self-contained — the whole feature.
+- **US2 (P2)**: out of scope for this repo (research.md §R7). T015 is a
+  consumer-side verification only and depends on T014.
+
+### Within User Story 1
+
+- Email-template payload interface (T007) → its `email-template-payload/index.ts`
+  export (T008).
+- Wire type (T002) + email-template payload (T007) → builder method (T009).
+- The Nunjucks template (T010) and the `@EventPattern` handler (T011) are
+  independent of the other US1 tasks (different files; T011 needs only the
+  Phase 2 enum + wire type).
+- Builder method (T009) + template (T010) → the two `notification.service.ts`
+  switch cases (T012).
+- All US1 implementation (T009–T012) → unit coverage (T013) → validation (T014).
+
+### One file per task — no serialization needed
+
+Every implementation task in this feature edits a distinct file — no two tasks
+touch the same file, so each is independently committable:
+
+| File | Task |
+|------|------|
+| `lib/src/dto/email-change/notification.event.payload.user.email.change.space.admin.ts` (NEW) | T002 |
+| `lib/src/dto/index.ts` | T003 |
+| `lib/package.json` | T004 |
+| `service/src/generated/alkemio-schema.ts` | T005 |
+| `service/package.json` | T006 |
+| `service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts` (NEW) | T007 |
+| `service/src/services/notification/email-template-payload/index.ts` | T008 |
+| `service/src/services/notification/notification.email.payload.builder.service.ts` | T009 |
+| `service/src/email-templates/space.admin.user.email.change.js` (NEW) | T010 |
+| `service/src/app.controller.ts` | T011 |
+| `service/src/services/notification/notification.service.ts` | T012 |
+| `service/src/services/notification/notification.service.spec.ts` | T013 |
+
+### Parallel Opportunities
+
+- **Foundational**: T002 ∥ T004 ∥ T005 (three different files, no
+  interdependency). Then T003 (after T002), then T006 (after T002, T003, T004).
+- **US1**: T007 ∥ T010 ∥ T011 (three different files; each depends only on the
+  completed Foundational phase). Then T008 ∥ T009 (after T007). Then T012, T013,
+  T014 in sequence.
+- **Polish**: T016 ∥ T017.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Foundational (T002–T006), launch US1's independent file tasks together:
+Task: "T007 Create email-template payload in service/src/services/notification/email-template-payload/space.admin.user.email.change.email.payload.ts"
+Task: "T010 Create Nunjucks template in service/src/email-templates/space.admin.user.email.change.js"
+Task: "T011 Add the @EventPattern handler in service/src/app.controller.ts"
+
+# Then sequence: T008 (after T007) ∥ T009 (after T007)
+#                → T012 (after T009, T010) → T013 → T014
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1: Setup (T001).
+2. Phase 2: Foundational (T002–T006) — **blocks all user story work**.
+3. Phase 3: User Story 1 (T007–T014).
+4. **STOP and VALIDATE**: T014 — the space-admin email-change notification works
+   end to end via quickstart Path A.
+5. Deploy/demo if ready — US1 delivers the whole value of the feature
+   (spec.md US1 rationale).
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → validate (T014) → deploy/demo — the feature is delivered (MVP).
+3. US2 → no implementation in this repo; run the consumer-side verification
+   (T015) once US1 is live.
+4. Polish (T016–T019) → static checks, regression, and the full acceptance pass.
+
+### Parallel Team Strategy
+
+The feature is small and single-story. One developer carries Foundational → US1
+→ Polish. If parallelised, T002 ∥ T004 ∥ T005 in Foundational and
+T007 ∥ T010 ∥ T011 in US1 are the only meaningful concurrency.
+
+---
+
+## Notes
+
+- **[P]** = different file, no dependency on an incomplete task.
+- **[Story]** label maps each task to a user story for traceability.
+- `service/` consumes `@alkemio/notifications-lib` as a versioned dependency, not
+  a workspace link — after changing `lib/`, rebuild it and make `0.16.0`
+  resolvable to `service/` (`npm pack` + install the tarball, or `npm link`)
+  before the service will compile or run (T006).
+- Template filename ↔ switch string: `getEmailTemplateToUseForEvent` returns the
+  template filename **without** the `.js` extension — file
+  `space.admin.user.email.change.js` → returns `'space.admin.user.email.change'`.
+- `initiatorRole` wire values are lowercase `'self'` / `'platform_admin'`;
+  `triggerOutcome` values are uppercase `'COMMITTED'` / `'DRIFT_DETECTED'`
+  (data-model.md §4) — compare against these exact literals. `triggerOutcome` is
+  carried on the wire payload for parity with the global-admin event but is
+  **not consumed** — there is no drift variant (FR-014, research.md §R9).
+- When T005 lands the enum member, the data-driven `event routing — all
+  NotificationEvent types` test in `notification.service.spec.ts` immediately
+  includes the new event and will **fail** until the switch cases (T012) are in
+  place — expected mid-implementation; the suite returns green after T012.
+- The new payload extends `NotificationEventPayloadSpace`, so the
+  `@EventPattern` handler is a thin pass-through with **no** normalization —
+  unlike 004 events 1 & 2, and like 004's global-admin handler (research.md §R4).
+- The opt-out preference (FR-009 / FR-010) generates **no tasks** in this repo
+  (research.md §R7) — it is server- and client-side work tracked in the sibling
+  specs.
+- Commit after each task or logical group; stop at the US1 checkpoint to
+  validate the feature independently.


### PR DESCRIPTION
## Summary

> **Stacked on #504** (base branch: `004-email-change-notifications`). Review/merge #504 first — GitHub will retarget this PR to `develop` once #504 merges.

Adds the **space-admin email-change notification**: when a user's login email changes, the notifications service delivers a per-space email to the admins and leads of every space that user is a member of.

- `specs/005-space-admin-email-change/` — full spec-kit artifact set.
- `lib`: new `NotificationEventPayloadUserEmailChangeSpaceAdmin` wire type; version `0.15.0 → 0.16.0`.
- `service`: `NotificationEvent` enum member, `@EventPattern` pass-through handler, email-template payload + builder method, Nunjucks template, the two `notification.service` switch cases, and unit coverage.

The notifications service is a thin pass-through — per-space fan-out and recipient resolution (each space's admins/leads, minus the subject, minus opted-out admins) happen server-side in `alkemio-server`.

## Test plan

- [ ] `npm run build` (lib + service) and `npm test` (service) pass
- [ ] Publish `USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION` via RabbitMQ (quickstart.md Path A) and confirm one email per recipient in MailSlurper

🤖 Generated with [Claude Code](https://claude.com/claude-code)