### PR TITLE
ci: multi-arch releases via native arm64 runners (no QEMU)

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -23,7 +23,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -41,7 +41,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -22,7 +22,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -22,7 +22,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -7,7 +7,27 @@ name: Deploy to DockerHub
 
 on:
   release:
-    types: [published]
+    # `released` additionally covers a pre-release later promoted to a full
+    # release (promotion fires no `published` event, so latest/vMAJOR would
+    # otherwise never be applied). A normal stable publish fires BOTH types;
+    # the two runs serialize via the concurrency group and are idempotent —
+    # a few duplicate runner-minutes buy the promotion path.
+    types: [published, released]
+  # TEMPORARY (validation only — removed before merge): exercise the full
+  # build+merge path from this branch; pushes only a sha-prefixed test tag.
+  push:
+    branches: [ci/multi-arch-native-runners]
+
+# Serialize whole runs against each other (the per-arch builds inside one run
+# still parallelize): two releases published minutes apart must apply their
+# floating tags (latest, vMAJOR, vMAJOR.MINOR) in publish order, or the older
+# release's slower run could re-point them backward.
+concurrency:
+  group: dockerhub-release
+  cancel-in-progress: false
+
+env:
+  REGISTRY_IMAGE: alkemio/${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -17,17 +37,17 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
+            pair: linux-amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            pair: linux-arm64
     runs-on: ${{ matrix.runner }}
+    # A hung build must not hold the release (and the concurrency queue)
+    # for the 6h default; normal builds take ~3 min.
+    timeout-minutes: 30
     permissions:
       contents: read    # Required for actions/checkout
     steps:
-      - name: Prepare platform slug
-        run: |
-          platform="${{ matrix.platform }}"
-          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-
       - name: Checkout
         uses: actions/checkout@v6.0.3
 
@@ -36,7 +56,7 @@ jobs:
         uses: docker/metadata-action@v6.1.0
         with:
           # Image name derived from repo name (e.g., alkemio/notifications)
-          images: alkemio/${{ github.event.repository.name }}
+          images: ${{ env.REGISTRY_IMAGE }}
           # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
@@ -57,10 +77,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           # Untagged push; the merge job assembles the manifest list from digests.
-          outputs: type=image,name=alkemio/${{ github.event.repository.name }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           # Registry cache, one ref per arch so the builders don't evict each other
-          cache-from: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache-${{ env.PLATFORM_PAIR }}
-          cache-to: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }},mode=max
           # SLSA provenance attestation for supply chain security
           provenance: mode=max
           # A machine-readable inventory of all components, libraries, and dependencies in your container image. It lists package names, versions,
@@ -79,22 +99,30 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.pair }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
-          retention-days: 1
+          # Recovery window: a failed merge can be re-run from these digests
+          # without rebuilding for up to a week.
+          retention-days: 7
 
   merge:
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6.1.0
+        env:
+          # Also emit OCI annotations targeting the manifest list (index),
+          # applied by imagetools create below — labels on the per-arch image
+          # configs alone are invisible to tooling reading the tagged index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
-          images: alkemio/${{ github.event.repository.name }}
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
@@ -112,6 +140,18 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Verify digest set
+        # Publishing from a partial set would silently ship a single-arch
+        # index under all release tags ('imagetools create' happily performs
+        # a one-source carbon copy). Also turns the expired-artifacts case
+        # (>7d-late re-run) into a clear error instead of a cryptic one.
+        run: |
+          count=$(ls -1 "${{ runner.temp }}/digests" 2>/dev/null | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::expected 2 digest files (amd64 + arm64), found ${count}. If the artifacts expired (retention 7d), re-run the whole workflow, not just this job."
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 
@@ -123,10 +163,22 @@ jobs:
 
       - name: Create multi-arch manifest and push
         working-directory: ${{ runner.temp }}/digests
+        # Tag/annotation args are built as a bash array: annotation values
+        # (e.g. image description) contain spaces, so the naive
+        # jq-into-word-splitting from the docs example would mangle them.
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'alkemio/${{ github.event.repository.name }}@sha256:%s ' *)
+          declare -a args
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          while IFS= read -r ann; do
+            args+=(--annotation "$ann")
+          done < <(jq -cr '.annotations[]?' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create "${args[@]}" \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect "alkemio/${{ github.event.repository.name }}:${{ steps.meta.outputs.version }}"
+        # Inspect the primary tag actually pushed (meta.outputs.version can be
+        # empty for tags matching no semver pattern, which would fail this step
+        # red after a successful publish).
+        run: docker buildx imagetools inspect "$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -33,24 +33,24 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.1.0
         with:
           # Image name derived from repo name (e.g., alkemio/notifications)
           images: alkemio/${{ github.event.repository.name }}
           # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           file: ./Dockerfile
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.1.0
         with:
           images: alkemio/${{ github.event.repository.name }}
           tags: |
@@ -113,10 +113,10 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -8,10 +8,6 @@ name: Deploy to DockerHub
 on:
   release:
     types: [published]
-  # TEMPORARY (validation only — removed before merge): exercise the full
-  # build+merge path from this branch; pushes only a sha-prefixed test tag.
-  push:
-    branches: [ci/multi-arch-native-runners]
 
 jobs:
   build:

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -1,18 +1,37 @@
-# Builds and publishes the linux/amd64 Docker image to Docker Hub.
-# Triggered only on GitHub releases (not PRs or pushes), so push/login
-# operations are always safe to execute unconditionally.
+# Builds and publishes the multi-arch (linux/amd64 + linux/arm64) Docker image
+# to Docker Hub. Each architecture builds NATIVELY on its own runner (no QEMU —
+# emulated npm/tsc builds hang, see the May 2026 arm64 revert), pushes by
+# digest, and a final job stitches the digests into one manifest list.
+# Triggered only on GitHub releases, so push/login operations are always safe.
 name: Deploy to DockerHub
 
 on:
   release:
     types: [published]
+  # TEMPORARY (validation only — removed before merge): exercise the full
+  # build+merge path from this branch; pushes only a sha-prefixed test tag.
+  push:
+    branches: [ci/multi-arch-native-runners]
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read    # Required for actions/checkout
     steps:
+      - name: Prepare platform slug
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v6.0.3
 
@@ -20,15 +39,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5.10.0
         with:
-          # Image name derived from repo name (e.g., alkemio/whiteboard-collaboration-service)
+          # Image name derived from repo name (e.g., alkemio/notifications)
           images: alkemio/${{ github.event.repository.name }}
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            # Only tag as 'latest' for stable releases, not prereleases
-            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
-            type=sha,prefix=sha-
+          # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0
@@ -39,20 +52,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6.19.2
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Registry cache - persists indefinitely on Docker Hub (no 7-day expiry)
-          # Pull cache from registry (visible in logs as "importing cache manifest")
-          cache-from: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache
-          # Push cache to registry (visible in logs as "exporting cache")
-          cache-to: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache,mode=max
+          # Untagged push; the merge job assembles the manifest list from digests.
+          outputs: type=image,name=alkemio/${{ github.event.repository.name }},push-by-digest=true,name-canonical=true,push=true
+          # Registry cache, one ref per arch so the builders don't evict each other
+          cache-from: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
           # SLSA provenance attestation for supply chain security
           provenance: mode=max
           # A machine-readable inventory of all components, libraries, and dependencies in your container image. It lists package names, versions,
@@ -61,3 +73,64 @@ jobs:
           #  - Compliance audits
           #  - Supply chain transparency
           sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5.10.0
+        with:
+          images: alkemio/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            # Only tag as 'latest' for stable releases, not prereleases.
+            # The event_name guard matters: on non-release events
+            # `github.event.release.prerelease == false` coerces null==false -> true.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+            type=sha,prefix=sha-
+
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'alkemio/${{ github.event.repository.name }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "alkemio/${{ github.event.repository.name }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -13,10 +13,6 @@ on:
     # the two runs serialize via the concurrency group and are idempotent —
     # a few duplicate runner-minutes buy the promotion path.
     types: [published, released]
-  # TEMPORARY (validation only — removed before merge): exercise the full
-  # build+merge path from this branch; pushes only a sha-prefixed test tag.
-  push:
-    branches: [ci/multi-arch-native-runners]
 
 # Serialize whole runs against each other (the per-arch builds inside one run
 # still parallelize): two releases published minutes apart must apply their


### PR DESCRIPTION
Restores linux/arm64 image publishing — this time without QEMU, so it cannot hang.

## History
- #446 (Jan) added multi-arch via QEMU emulation — the same pattern the Go services use.
- `a06353d` (May 22) dropped arm64 because the emulated build hung: under qemu-user the **entire Node toolchain** (`npm ci` ×2 + `tsc`) runs emulated, which is pathologically slow/stalls. Go builds tolerate emulation; Node builds don't.
- Net effect: every release since (incl. v0.35.0) is amd64-only, forcing `platform: linux/amd64` workarounds on Apple Silicon (cf. alkem-io/server#6116).

## Approach (Docker's documented multi-runner pattern)
- `build` matrix: each arch builds **natively** — `ubuntu-latest` for amd64, GitHub's free hosted `ubuntu-24.04-arm` for arm64. No QEMU anywhere.
- Each build pushes **by digest** (untagged), uploads the digest as an artifact.
- `merge` job stitches the digests into one manifest list with `docker buildx imagetools create` and applies the metadata-action tags.
- Registry build cache split per arch (`buildcache-linux-amd64` / `-linux-arm64`) so the builders don't evict each other. Provenance (mode=max) + SBOM kept from the current workflow.
- Fixed a latent tag bug while here: `enable=${{ github.event.release.prerelease == false }}` coerces `null == false` → **true** on non-release events; now guarded with `event_name == 'release'`.

## Validated end-to-end (real run, temporary push trigger since removed)
Run [27438537984](https://github.com/alkem-io/notifications/actions/runs/27438537984): both arch builds **~3 min each**, merge OK. Pushed test tag `sha-28bfdc9` → manifest list contains `linux/amd64, linux/arm64`; `:latest` untouched (guard verified). The test tag can be deleted from Docker Hub by anyone with credentials — it's inert otherwise.

## Follow-ups (not this PR)
- After the next release ships multi-arch: drop the `platform: linux/amd64` override for `notification` in server's `quickstart-services.yml` (being touched in alkem-io/server#6116) and bump the pinned image tag.
- Same pattern is the template for the other amd64-only Node/Python images (server, client-web, virtual-contributor) — and likely supersedes the Apple-Silicon-self-hosted-runner asks in oidc-service#16 / matrix-adapter#30.