### PR TITLE
chore: standardize k8s deployment manifests (dev/test)

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: Azure/k8s-deploy@v5.1.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/25-notifications-deployment-dev.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: Azure/k8s-deploy@v5.1.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/25-notifications-deployment-dev.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: Azure/k8s-deploy@v5.1.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/26-notifications-deployment-test.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/manifests/25-notifications-deployment-dev.yaml
+++ b/manifests/25-notifications-deployment-dev.yaml
@@ -1,11 +1,11 @@
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   namespace: default
   name: alkemio-notifications-deployment
   labels:
     app: alkemio-notifications
-
+    k8s-app: alkemio-notifications
 spec:
   replicas: 1
   selector:
@@ -50,3 +50,48 @@ spec:
                 name: alkemio-secrets
             - configMapRef:
                 name: alkemio-config
+          resources:
+            requests:
+              cpu: 150m
+              memory: 150Mi
+            limits:
+              cpu: 250m
+              memory: 250Mi
+          # probes
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname

--- a/manifests/26-notifications-deployment-test.yaml
+++ b/manifests/26-notifications-deployment-test.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: alkemio-notifications-deployment
+  labels:
+    app: alkemio-notifications
+    k8s-app: alkemio-notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alkemio-notifications
+  template:
+    metadata:
+      labels:
+        app: alkemio-notifications
+    spec:
+      containers:
+        - name: alkemio-notifications
+          image: rg.nl-ams.scw.cloud/alkemio/alkemio-notifications:latest
+          env:
+            - name: RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: host
+            - name: RABBITMQ_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: port
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: username
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: password
+            - name: ALKEMIO_WEBCLIENT_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: ENDPOINT_CLUSTER
+          envFrom:
+            - secretRef:
+                name: alkemio-secrets
+            - configMapRef:
+                name: alkemio-config
+          resources:
+            requests:
+              cpu: 150m
+              memory: 150Mi
+            limits:
+              cpu: 250m
+              memory: 250Mi
+          # probes
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

Standardizes the per-repo k8s `manifests/` set for **notifications** to the server/client-web/file-service fleet convention (`25-…-dev` / `26-…-test`, deployment named `alkemio-notifications-deployment`, container `alkemio-notifications`).

## Deployment set (NO Service — and why)

notifications has **no inbound traffic**. The dev-orchestration base for notifications is a Deployment only (`11-notifications-deployment.yml`) — no Service, no ingress. Accordingly this PR ships **deployment manifests only**; **no Service manifest is created**.

- `manifests/25-notifications-deployment-dev.yaml`
- `manifests/26-notifications-deployment-test.yaml`

There are no notifications overlays in dev-orch (single base, no `overlays/*/…/notifications`), so dev and test are **byte-identical** in content — they differ only by filename, mirroring the single authoritative base.

## Manifest location decision + workflow path update

The manifest previously lived at `service/manifests/25-notifications-deployment-dev.yaml`, and **all three** deploy workflows (`build-deploy-k8s-{dev,test,sandbox}-hetzner.yml`) passed that path to `Azure/k8s-deploy`, which **applies** the manifest as live desired state — so path correctness is load-bearing.

To match the fleet (`manifests/` at repo root), the file is **moved to `manifests/`** and **every workflow `manifests:` reference is updated in the same PR** (only the `manifests:` path line is touched — nothing else in the workflows):

| Workflow | old `manifests:` | new `manifests:` |
|---|---|---|
| dev | `service/manifests/25-notifications-deployment-dev.yaml` | `manifests/25-notifications-deployment-dev.yaml` |
| sandbox | `service/manifests/25-notifications-deployment-dev.yaml` | `manifests/25-notifications-deployment-dev.yaml` |
| test | `service/manifests/25-notifications-deployment-dev.yaml` | `manifests/26-notifications-deployment-test.yaml` |

Note: previously **all three** workflows applied the **dev** file (a latent inconsistency). The test workflow now correctly points at the test manifest; sandbox continues to track the dev manifest. All three updated paths were verified to resolve to existing files.

## dev-orch reconciliation

The pre-existing repo manifest was missing fields present in the authoritative dev-orch base. Reconciled the dev/test manifests to the base by adding:
- `k8s-app: alkemio-notifications` label
- `resources` (requests 150m/150Mi, limits 250m/250Mi)
- readiness + liveness probes (`/health` on port 4004)
- pod affinity (rabbitmq) / anti-affinity (alkemio-server)

The image is kept as `…/alkemio-notifications:latest` (the deploy action overrides the tag via its `images:` input at apply time), matching the repo's prior manifest and the client-web convention.

## Validation

- Both manifests parse as valid YAML and assert kind=Deployment, name=`alkemio-notifications-deployment`, container=`alkemio-notifications`, with resources + both probes.
- All three workflow files still parse as valid YAML; every `manifests:` path resolves to an existing file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced notification service deployment configurations with health checks and resource management to improve system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->