### PR TITLE
Release 0.35.1

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/25-notifications-deployment-dev.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -23,7 +23,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -41,7 +41,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -22,7 +22,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/25-notifications-deployment-dev.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6.0.3
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -22,7 +22,7 @@ jobs:
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
             service/manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: Azure/k8s-deploy@v6.0.0
         with:
           manifests: |
-            service/manifests/25-notifications-deployment-dev.yaml
+            manifests/26-notifications-deployment-test.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-notifications:${{ github.sha }}
           imagepullsecrets: |

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -1,15 +1,46 @@
-# Builds and publishes the linux/amd64 Docker image to Docker Hub.
-# Triggered only on GitHub releases (not PRs or pushes), so push/login
-# operations are always safe to execute unconditionally.
+# Builds and publishes the multi-arch (linux/amd64 + linux/arm64) Docker image
+# to Docker Hub. Each architecture builds NATIVELY on its own runner (no QEMU —
+# emulated npm/tsc builds hang, see the May 2026 arm64 revert), pushes by
+# digest, and a final job stitches the digests into one manifest list.
+# Triggered only on GitHub releases, so push/login operations are always safe.
 name: Deploy to DockerHub
 
 on:
   release:
-    types: [published]
+    # `released` additionally covers a pre-release later promoted to a full
+    # release (promotion fires no `published` event, so latest/vMAJOR would
+    # otherwise never be applied). A normal stable publish fires BOTH types;
+    # the two runs serialize via the concurrency group and are idempotent —
+    # a few duplicate runner-minutes buy the promotion path.
+    types: [published, released]
+
+# Serialize whole runs against each other (the per-arch builds inside one run
+# still parallelize): two releases published minutes apart must apply their
+# floating tags (latest, vMAJOR, vMAJOR.MINOR) in publish order, or the older
+# release's slower run could re-point them backward.
+concurrency:
+  group: dockerhub-release
+  cancel-in-progress: false
+
+env:
+  REGISTRY_IMAGE: alkemio/${{ github.event.repository.name }}
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            pair: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            pair: linux-arm64
+    runs-on: ${{ matrix.runner }}
+    # A hung build must not hold the release (and the concurrency queue)
+    # for the 6h default; normal builds take ~3 min.
+    timeout-minutes: 30
     permissions:
       contents: read    # Required for actions/checkout
     steps:
@@ -18,41 +49,34 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.1.0
         with:
-          # Image name derived from repo name (e.g., alkemio/whiteboard-collaboration-service)
-          images: alkemio/${{ github.event.repository.name }}
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            # Only tag as 'latest' for stable releases, not prereleases
-            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
-            type=sha,prefix=sha-
+          # Image name derived from repo name (e.g., alkemio/notifications)
+          images: ${{ env.REGISTRY_IMAGE }}
+          # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6.19.2
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Registry cache - persists indefinitely on Docker Hub (no 7-day expiry)
-          # Pull cache from registry (visible in logs as "importing cache manifest")
-          cache-from: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache
-          # Push cache to registry (visible in logs as "exporting cache")
-          cache-to: type=registry,ref=alkemio/${{ github.event.repository.name }}:buildcache,mode=max
+          # Untagged push; the merge job assembles the manifest list from digests.
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Registry cache, one ref per arch so the builders don't evict each other
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }},mode=max
           # SLSA provenance attestation for supply chain security
           provenance: mode=max
           # A machine-readable inventory of all components, libraries, and dependencies in your container image. It lists package names, versions,
@@ -61,3 +85,96 @@ jobs:
           #  - Compliance audits
           #  - Supply chain transparency
           sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digests-${{ matrix.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          # Recovery window: a failed merge can be re-run from these digests
+          # without rebuilding for up to a week.
+          retention-days: 7
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        env:
+          # Also emit OCI annotations targeting the manifest list (index),
+          # applied by imagetools create below — labels on the per-arch image
+          # configs alone are invisible to tooling reading the tagged index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            # Only tag as 'latest' for stable releases, not prereleases.
+            # The event_name guard matters: on non-release events
+            # `github.event.release.prerelease == false` coerces null==false -> true.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+            type=sha,prefix=sha-
+
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Verify digest set
+        # Publishing from a partial set would silently ship a single-arch
+        # index under all release tags ('imagetools create' happily performs
+        # a one-source carbon copy). Also turns the expired-artifacts case
+        # (>7d-late re-run) into a clear error instead of a cryptic one.
+        run: |
+          count=$(ls -1 "${{ runner.temp }}/digests" 2>/dev/null | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::expected 2 digest files (amd64 + arm64), found ${count}. If the artifacts expired (retention 7d), re-run the whole workflow, not just this job."
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest and push
+        working-directory: ${{ runner.temp }}/digests
+        # Tag/annotation args are built as a bash array: annotation values
+        # (e.g. image description) contain spaces, so the naive
+        # jq-into-word-splitting from the docs example would mangle them.
+        run: |
+          declare -a args
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          while IFS= read -r ann; do
+            args+=(--annotation "$ann")
+          done < <(jq -cr '.annotations[]?' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create "${args[@]}" \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        # Inspect the primary tag actually pushed (meta.outputs.version can be
+        # empty for tags matching no semver pattern, which would fail this step
+        # red after a successful publish).
+        run: docker buildx imagetools inspect "$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read    # Required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Docker meta
         id: meta

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 > **Workspace context.** This repo is part of the Alkemio polyrepo at
-> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> [alkem-io/agents-hq](https://github.com/alkem-io/agents-hq).
 > Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
 > working on a `feat/NNN-...` branch in this repo, the matching workspace
 > spec is the single source of truth.

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -8779,9 +8779,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -2404,13 +2404,13 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -5171,14 +5171,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
+        "synckit": "^0.11.13"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -9808,13 +9808,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -4250,26 +4250,26 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4279,39 +4279,31 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -5786,9 +5778,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7801,37 +7793,37 @@
       "peer": true
     },
     "node_modules/lint-staged": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
-      "integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.6.tgz",
+      "integrity": "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
+        "chalk": "^5.6.0",
         "commander": "^14.0.0",
         "debug": "^4.4.1",
         "lilconfig": "^3.1.3",
-        "listr2": "^8.3.3",
+        "listr2": "^9.0.3",
         "micromatch": "^4.0.8",
         "nano-spawn": "^1.0.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.1"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.17"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7842,13 +7834,13 @@
       }
     },
     "node_modules/listr2": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^4.0.0",
+        "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
         "eventemitter3": "^5.0.1",
         "log-update": "^6.1.0",
@@ -7856,7 +7848,7 @@
         "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -9441,26 +9433,26 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9471,13 +9463,16 @@
       }
     },
     "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10717,9 +10712,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10727,6 +10722,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/notifications-lib",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/notifications-lib",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "0.36.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -51,7 +51,7 @@
     "npm": ">=8.5.5"
   },
   "volta": {
-    "node": "20.15.1"
+    "node": "20.20.2"
   },
   "publishConfig": {
     "access": "public",

--- a/manifests/25-notifications-deployment-dev.yaml
+++ b/manifests/25-notifications-deployment-dev.yaml
@@ -1,11 +1,11 @@
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   namespace: default
   name: alkemio-notifications-deployment
   labels:
     app: alkemio-notifications
-
+    k8s-app: alkemio-notifications
 spec:
   replicas: 1
   selector:
@@ -50,3 +50,48 @@ spec:
                 name: alkemio-secrets
             - configMapRef:
                 name: alkemio-config
+          resources:
+            requests:
+              cpu: 150m
+              memory: 150Mi
+            limits:
+              cpu: 250m
+              memory: 250Mi
+          # probes
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname

--- a/manifests/26-notifications-deployment-test.yaml
+++ b/manifests/26-notifications-deployment-test.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: alkemio-notifications-deployment
+  labels:
+    app: alkemio-notifications
+    k8s-app: alkemio-notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alkemio-notifications
+  template:
+    metadata:
+      labels:
+        app: alkemio-notifications
+    spec:
+      containers:
+        - name: alkemio-notifications
+          image: rg.nl-ams.scw.cloud/alkemio/alkemio-notifications:latest
+          env:
+            - name: RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: host
+            - name: RABBITMQ_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: port
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: username
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: password
+            - name: ALKEMIO_WEBCLIENT_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: ENDPOINT_CLUSTER
+          envFrom:
+            - secretRef:
+                name: alkemio-secrets
+            - configMapRef:
+                name: alkemio-config
+          resources:
+            requests:
+              cpu: 150m
+              memory: 150Mi
+            limits:
+              cpu: 250m
+              memory: 250Mi
+          # probes
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4004
+              httpHeaders:
+                - name: Host
+                  value: '127.0.0.1'
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-notifications",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/notifications-lib": "0.17.0",
@@ -6973,13 +6973,13 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -11628,14 +11628,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
+        "synckit": "^0.11.13"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -19800,13 +19800,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -26384,9 +26384,9 @@
       "optional": true
     },
     "@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true
     },
     "@protobufjs/aspromise": {
@@ -29701,13 +29701,13 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
+        "synckit": "^0.11.13"
       }
     },
     "eslint-scope": {
@@ -35041,12 +35041,12 @@
       }
     },
     "synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "requires": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       }
     },
     "table-layout": {

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -13161,9 +13161,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
-      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -30635,9 +30635,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
-      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg=="
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="
     },
     "graphql-config": {
       "version": "5.1.5",

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -17975,9 +17975,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -33845,9 +33845,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -13161,9 +13161,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
-      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
+      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -30635,9 +30635,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
-      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q=="
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
+      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg=="
     },
     "graphql-config": {
       "version": "5.1.5",

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-notifications",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Alkemio notifications service",
   "author": "Alkemio Foundation",
   "private": false,


### PR DESCRIPTION
Cuts **v0.35.1** — the first **multi-arch (amd64 + arm64)** notifications release.

## What's in it (develop → main)
- **ci: multi-arch releases via native arm64 runners, no QEMU (#525)** — the release workflow now builds each arch natively (ubuntu-latest + ubuntu-24.04-arm), pushes by digest, and stitches a manifest list. This is what makes v0.35.1 the first arm64 image.
- **chore: standardize k8s deployment manifests (dev/test) (#526)** — dev-orch-aligned reference manifests.
- Dependency refreshes: graphql 16.14.2, prettier 3.8.4, eslint-plugin-prettier 5.5.6, GitHub Actions v6.0.3, linting/formatting bumps.
- Version bump: `service/package.json` 0.35.0 → **0.35.1**.

## After merge
Tag/release **v0.35.1** off `main` → the `release: published` workflow publishes `alkemio/notifications:v0.35.1` (amd64 + arm64) to Docker Hub. This then unblocks dropping the `platform: linux/amd64` workaround for notifications in server's quickstart.

(`develop` fully contains `main`, so this merge is conflict-free.)