### PR TITLE
feat(019): TypeScript 7 (native tsgo) upgrade

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -28,3 +28,31 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Typecheck (native TS7)
+        run: npm run typecheck:native
+
+  lint-lib:
+    runs-on: arc-runner-set
+    defaults:
+      run:
+        working-directory: lib
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '20.20.2'
+          cache: 'npm'
+          cache-dependency-path: lib/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck (native TS7)
+        run: npm run typecheck:native

--- a/lib/.prettierrc
+++ b/lib/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+}

--- a/lib/eslint.config.js
+++ b/lib/eslint.config.js
@@ -1,0 +1,64 @@
+const tsParser = require('@typescript-eslint/parser');
+const typescriptEslintEslintPlugin = require('@typescript-eslint/eslint-plugin');
+const prettier = require('eslint-plugin-prettier');
+const globals = require('globals');
+const js = require('@eslint/js');
+
+const { FlatCompat } = require('@eslint/eslintrc');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+const env = (prod, dev) => (process.env.NODE_ENV === 'production' ? prod : dev);
+
+module.exports = [
+  {
+    ignores: ['**/node_modules/**/*', '**/dist/**'],
+  },
+  ...compat.extends(
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+    'prettier'
+  ),
+  {
+    languageOptions: {
+      parser: tsParser,
+      sourceType: 'module',
+
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+
+    plugins: {
+      prettier,
+    },
+
+    rules: {
+      quotes: ['error', 'single'],
+      'no-console': env(1, 0),
+      'no-debugger': env(1, 0),
+      '@typescript-eslint/interface-name-prefix': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+
+      '@typescript-eslint/no-unused-vars': [
+        env(2, 1),
+        {
+          argsIgnorePattern: '^_',
+        },
+      ],
+
+      'no-multiple-empty-lines': 'error',
+    },
+  },
+];

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -12,19 +12,23 @@
         "@alkemio/client-lib": "0.36.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^9.32.0",
         "@types/node": "^20.19.0",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
+        "@typescript/native": "npm:typescript@7.0.2",
         "dotenv": "^17.2.1",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.3",
+        "globals": "^14.0.0",
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "npm:@typescript/typescript6@^6.0.2"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -3031,6 +3035,397 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -9917,17 +10312,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/ua-parser-js": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -16,27 +16,32 @@
     "build": "tsc --project tsconfig.prod.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "lint": "tsc --noEmit && eslint src/**/*.ts{,x}",
-    "lint:prod": "tsc --noEmit && cross-env NODE_ENV=production eslint src/**/*.ts{,x}",
-    "lint:fix": "tsc --noEmit && eslint src/**/*.ts{,x} --fix"
+    "lint": "npm run typecheck:native && eslint src/**/*.ts{,x}",
+    "lint:prod": "npm run typecheck:native && cross-env NODE_ENV=production eslint src/**/*.ts{,x}",
+    "lint:fix": "npm run typecheck:native && eslint src/**/*.ts{,x} --fix",
+    "typecheck:native": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@alkemio/client-lib": "0.36.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^9.32.0",
     "@types/node": "^20.19.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
+    "@typescript/native": "npm:typescript@7.0.2",
     "dotenv": "^17.2.1",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.3",
+    "globals": "^14.0.0",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "_moduleAliases": {
     "@src": "./dist"

--- a/lib/package.json
+++ b/lib/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc --project tsconfig.prod.json",
+    "build": "tsc6 --project tsconfig.prod.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "lint": "npm run typecheck:native && eslint src/**/*.ts{,x}",

--- a/lib/src/dto/base.event.payload.ts
+++ b/lib/src/dto/base.event.payload.ts
@@ -1,12 +1,12 @@
-import { User } from "@alkemio/client-lib";
-import { ContributorPayload } from "./contributor.payload";
-import { UserPayload } from "./user.payload";
+import { User } from '@alkemio/client-lib';
+import { ContributorPayload } from './contributor.payload';
+import { UserPayload } from './user.payload';
 
 export interface BaseEventPayload {
-    eventType: string;
-    triggeredBy: UserPayload;
-    recipients: UserPayload[];
-    platform: {
-        url: string;
-    }
-} 
+  eventType: string;
+  triggeredBy: UserPayload;
+  recipients: UserPayload[];
+  platform: {
+    url: string;
+  };
+}

--- a/lib/src/dto/contributor.payload.ts
+++ b/lib/src/dto/contributor.payload.ts
@@ -1,9 +1,8 @@
-
 export type ContributorPayload = {
   id: string;
   profile: {
     displayName: string;
     url: string;
-  }
-  type: string
+  };
+  type: string;
 };

--- a/lib/src/dto/index.ts
+++ b/lib/src/dto/index.ts
@@ -17,4 +17,3 @@ export * from './user/notification.event.payload.user.email.change.global.admin'
 export * from './user/notification.event.payload.user.email.change.space.admin';
 export * from './user/notification.event.payload.user.password.change.security.signal';
 export * from './space';
-

--- a/lib/src/dto/organization/notification.event.payload.organization.message.direct.ts
+++ b/lib/src/dto/organization/notification.event.payload.organization.message.direct.ts
@@ -1,6 +1,5 @@
-import { NotificationEventPayloadOrganization } from "./notification.event.payload.organization";
+import { NotificationEventPayloadOrganization } from './notification.event.payload.organization';
 
-export interface NotificationEventPayloadOrganizationMessageDirect
-  extends NotificationEventPayloadOrganization {
+export interface NotificationEventPayloadOrganizationMessageDirect extends NotificationEventPayloadOrganization {
   message: string;
 }

--- a/lib/src/dto/organization/notification.event.payload.organization.message.room.ts
+++ b/lib/src/dto/organization/notification.event.payload.organization.message.room.ts
@@ -1,7 +1,6 @@
 import { NotificationEventPayloadOrganization } from './notification.event.payload.organization';
 
-export interface NotificationEventPayloadOrganizationMessageRoom
-  extends NotificationEventPayloadOrganization {
+export interface NotificationEventPayloadOrganizationMessageRoom extends NotificationEventPayloadOrganization {
   comment: string;
   commentOrigin: {
     url: string;

--- a/lib/src/dto/organization/notification.event.payload.organization.ts
+++ b/lib/src/dto/organization/notification.event.payload.organization.ts
@@ -1,7 +1,6 @@
-import { BaseEventPayload } from "../base.event.payload";
-import { ContributorPayload } from "../contributor.payload";
+import { BaseEventPayload } from '../base.event.payload';
+import { ContributorPayload } from '../contributor.payload';
 
-export interface NotificationEventPayloadOrganization
-  extends BaseEventPayload {
+export interface NotificationEventPayloadOrganization extends BaseEventPayload {
   organization: ContributorPayload;
 }

--- a/lib/src/dto/platform/notification.event.payload.invite.user.platform.ts
+++ b/lib/src/dto/platform/notification.event.payload.invite.user.platform.ts
@@ -1,12 +1,11 @@
-import { UserPayload } from "../user.payload";
-import { NotificationEventPayloadPlatform } from "./notification.event.payload.platform";
+import { UserPayload } from '../user.payload';
+import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
 
-export interface NotificationEventPayloadPlatformInviteUseToRole
-  extends NotificationEventPayloadPlatform {
-    user: UserPayload;
-    role: string;
-    invitees: {
-      email: string;
-    }[];
-    welcomeMessage?: string;
-};
+export interface NotificationEventPayloadPlatformInviteUseToRole extends NotificationEventPayloadPlatform {
+  user: UserPayload;
+  role: string;
+  invitees: {
+    email: string;
+  }[];
+  welcomeMessage?: string;
+}

--- a/lib/src/dto/platform/notification.event.payload.platform.forum.discussion.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.forum.discussion.ts
@@ -1,8 +1,7 @@
 import { ContributorPayload } from '../contributor.payload';
 import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
 
-export interface NotificationEventPayloadPlatformForumDiscussion
-  extends NotificationEventPayloadPlatform {
+export interface NotificationEventPayloadPlatformForumDiscussion extends NotificationEventPayloadPlatform {
   discussion: {
     id: string;
     displayName: string;

--- a/lib/src/dto/platform/notification.event.payload.platform.global.role.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.global.role.ts
@@ -1,10 +1,9 @@
-import { RoleChangeType } from "@src/common/enums/role.change.type";
-import { NotificationEventPayloadPlatform } from "./notification.event.payload.platform";
-import { UserPayload } from "../user.payload";
+import { RoleChangeType } from '@src/common/enums/role.change.type';
+import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
+import { UserPayload } from '../user.payload';
 
-export interface NotificationEventPayloadPlatformGlobalRole
-  extends NotificationEventPayloadPlatform {
+export interface NotificationEventPayloadPlatformGlobalRole extends NotificationEventPayloadPlatform {
   type: RoleChangeType;
-  user: UserPayload
+  user: UserPayload;
   role: string;
 }

--- a/lib/src/dto/platform/notification.event.payload.platform.space.created.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.space.created.ts
@@ -1,5 +1,5 @@
-import { SpacePayload } from "../space";
-import { NotificationEventPayloadPlatform } from "./notification.event.payload.platform";
+import { SpacePayload } from '../space';
+import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
 
 export interface NotificationEventPayloadPlatformSpaceCreated extends NotificationEventPayloadPlatform {
   space: SpacePayload;
@@ -7,5 +7,5 @@ export interface NotificationEventPayloadPlatformSpaceCreated extends Notificati
   sender: {
     name: string;
     url: string;
-  }
+  };
 }

--- a/lib/src/dto/platform/notification.event.payload.platform.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.ts
@@ -1,5 +1,3 @@
-import { BaseEventPayload } from "../base.event.payload";
+import { BaseEventPayload } from '../base.event.payload';
 
-export interface NotificationEventPayloadPlatform
-  extends BaseEventPayload {
-}
+export type NotificationEventPayloadPlatform = BaseEventPayload;

--- a/lib/src/dto/platform/notification.event.payload.platform.user.registration.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.user.registration.ts
@@ -1,7 +1,6 @@
-import { UserPayload } from "../user.payload";
-import { NotificationEventPayloadPlatform } from "./notification.event.payload.platform";
+import { UserPayload } from '../user.payload';
+import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
 
-export interface NotificationEventPayloadPlatformUserRegistration
-  extends NotificationEventPayloadPlatform {
-    user: UserPayload;
-};
+export interface NotificationEventPayloadPlatformUserRegistration extends NotificationEventPayloadPlatform {
+  user: UserPayload;
+}

--- a/lib/src/dto/platform/notification.event.payload.platform.user.removed.ts
+++ b/lib/src/dto/platform/notification.event.payload.platform.user.removed.ts
@@ -1,9 +1,8 @@
-import { NotificationEventPayloadPlatform } from "./notification.event.payload.platform";
+import { NotificationEventPayloadPlatform } from './notification.event.payload.platform';
 
-export interface NotificationEventPayloadPlatformUserRemoved
-  extends NotificationEventPayloadPlatform {
+export interface NotificationEventPayloadPlatformUserRemoved extends NotificationEventPayloadPlatform {
   user: {
     displayName: string;
     email: string;
-  }
-};
+  };
+}

--- a/lib/src/dto/space/notification.event.payload.space.calendar.event.ts
+++ b/lib/src/dto/space/notification.event.payload.space.calendar.event.ts
@@ -1,8 +1,7 @@
 import { UserPayload } from '../user.payload';
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 
-export interface NotificationEventPayloadSpaceCalendarEvent
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpaceCalendarEvent extends NotificationEventPayloadSpace {
   calendarEvent: {
     id: string;
     title: string;

--- a/lib/src/dto/space/notification.event.payload.space.collaboration.callout.ts
+++ b/lib/src/dto/space/notification.event.payload.space.collaboration.callout.ts
@@ -1,8 +1,7 @@
-import { ContributorPayload } from "../contributor.payload";
-import { NotificationEventPayloadSpace } from "./notification.event.payload.space";
+import { ContributorPayload } from '../contributor.payload';
+import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 
-export interface NotificationEventPayloadSpaceCollaborationCallout
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpaceCollaborationCallout extends NotificationEventPayloadSpace {
   callout: {
     id: string;
     framing: {

--- a/lib/src/dto/space/notification.event.payload.space.communication.message.direct.ts
+++ b/lib/src/dto/space/notification.event.payload.space.communication.message.direct.ts
@@ -1,6 +1,5 @@
-import { NotificationEventPayloadSpace } from "./notification.event.payload.space";
+import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 
-export interface NotificationEventPayloadSpaceCommunicationMessageDirect
-    extends NotificationEventPayloadSpace {
-    message: string;
+export interface NotificationEventPayloadSpaceCommunicationMessageDirect extends NotificationEventPayloadSpace {
+  message: string;
 }

--- a/lib/src/dto/space/notification.event.payload.space.community.contributor.ts
+++ b/lib/src/dto/space/notification.event.payload.space.community.contributor.ts
@@ -1,4 +1,3 @@
-
 import { ContributorPayload } from '../contributor.payload';
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 

--- a/lib/src/dto/space/notification.event.payload.space.community.invitation.platform.ts
+++ b/lib/src/dto/space/notification.event.payload.space.community.invitation.platform.ts
@@ -1,6 +1,5 @@
-import { NotificationEventPayloadSpace } from "./notification.event.payload.space";
+import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 
-export interface NotificationEventPayloadSpaceCommunityInvitationPlatform
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpaceCommunityInvitationPlatform extends NotificationEventPayloadSpace {
   welcomeMessage?: string;
 }

--- a/lib/src/dto/space/notification.event.payload.space.community.invitation.ts
+++ b/lib/src/dto/space/notification.event.payload.space.community.invitation.ts
@@ -1,8 +1,7 @@
 import { ContributorPayload } from '../contributor.payload';
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 
-export interface NotificationEventPayloadSpaceCommunityInvitation
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpaceCommunityInvitation extends NotificationEventPayloadSpace {
   invitee: ContributorPayload;
   welcomeMessage?: string;
 }

--- a/lib/src/dto/space/notification.event.payload.space.poll.modified.on.poll.i.voted.on.ts
+++ b/lib/src/dto/space/notification.event.payload.space.poll.modified.on.poll.i.voted.on.ts
@@ -1,7 +1,6 @@
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 import { PollPayload } from './poll.payload';
 
-export interface NotificationEventPayloadSpacePollModifiedOnPollIVotedOn
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpacePollModifiedOnPollIVotedOn extends NotificationEventPayloadSpace {
   poll: PollPayload;
 }

--- a/lib/src/dto/space/notification.event.payload.space.poll.vote.affected.by.option.change.ts
+++ b/lib/src/dto/space/notification.event.payload.space.poll.vote.affected.by.option.change.ts
@@ -1,7 +1,6 @@
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 import { PollPayload } from './poll.payload';
 
-export interface NotificationEventPayloadSpacePollVoteAffectedByOptionChange
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpacePollVoteAffectedByOptionChange extends NotificationEventPayloadSpace {
   poll: PollPayload;
 }

--- a/lib/src/dto/space/notification.event.payload.space.poll.vote.cast.on.own.poll.ts
+++ b/lib/src/dto/space/notification.event.payload.space.poll.vote.cast.on.own.poll.ts
@@ -1,7 +1,6 @@
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 import { PollPayload } from './poll.payload';
 
-export interface NotificationEventPayloadSpacePollVoteCastOnOwnPoll
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpacePollVoteCastOnOwnPoll extends NotificationEventPayloadSpace {
   poll: PollPayload;
 }

--- a/lib/src/dto/space/notification.event.payload.space.poll.vote.cast.on.poll.i.voted.on.ts
+++ b/lib/src/dto/space/notification.event.payload.space.poll.vote.cast.on.poll.i.voted.on.ts
@@ -1,7 +1,6 @@
 import { NotificationEventPayloadSpace } from './notification.event.payload.space';
 import { PollPayload } from './poll.payload';
 
-export interface NotificationEventPayloadSpacePollVoteCastOnPollIVotedOn
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadSpacePollVoteCastOnPollIVotedOn extends NotificationEventPayloadSpace {
   poll: PollPayload;
 }

--- a/lib/src/dto/space/notification.event.payload.space.ts
+++ b/lib/src/dto/space/notification.event.payload.space.ts
@@ -1,7 +1,6 @@
-import { BaseEventPayload } from "../base.event.payload";
-import { SpacePayload } from "./space.payload";
+import { BaseEventPayload } from '../base.event.payload';
+import { SpacePayload } from './space.payload';
 
-export interface NotificationEventPayloadSpace
-  extends BaseEventPayload {
+export interface NotificationEventPayloadSpace extends BaseEventPayload {
   space: SpacePayload;
 }

--- a/lib/src/dto/space/space.payload.ts
+++ b/lib/src/dto/space/space.payload.ts
@@ -1,10 +1,9 @@
-
 export type SpacePayload = {
   id: string;
   level: string;
   profile: {
     displayName: string;
     url: string;
-  }
+  };
   adminURL: string;
 };

--- a/lib/src/dto/user.payload.ts
+++ b/lib/src/dto/user.payload.ts
@@ -1,7 +1,7 @@
-import { ContributorPayload } from "./contributor.payload";
+import { ContributorPayload } from './contributor.payload';
 
 export interface UserPayload extends ContributorPayload {
   firstName: string;
   lastName: string;
   email: string;
-};
+}

--- a/lib/src/dto/user/notification.event.payload.user.email.change.global.admin.ts
+++ b/lib/src/dto/user/notification.event.payload.user.email.change.global.admin.ts
@@ -1,15 +1,14 @@
-import { BaseEventPayload } from "../base.event.payload";
+import { BaseEventPayload } from '../base.event.payload';
 
 // Event USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION — published via the
 // server's buildBaseEventPayload, so it carries the full BaseEventPayload
 // envelope including a server-resolved `recipients` array.
-export interface NotificationEventPayloadUserEmailChangeGlobalAdmin
-  extends BaseEventPayload {
+export interface NotificationEventPayloadUserEmailChangeGlobalAdmin extends BaseEventPayload {
   subjectProfileSummary: { id: string; displayName: string };
   oldEmail: string;
   newEmail: string;
   initiatorProfileSummary?: { id: string; displayName: string };
-  initiatorRole: "self" | "platform_admin";
+  initiatorRole: 'self' | 'platform_admin';
   // Who authorized the change within the subject's organization. Present for
   // platform-admin changes; absent for the self-service flow.
   approver?: { name: string; role: string; organization?: string };
@@ -17,7 +16,7 @@ export interface NotificationEventPayloadUserEmailChangeGlobalAdmin
   // changes; absent for the self-service flow.
   reason?: string;
   commitTimestampISO8601: string;
-  triggerOutcome: "COMMITTED" | "DRIFT_DETECTED";
+  triggerOutcome: 'COMMITTED' | 'DRIFT_DETECTED';
   subjectMemberships?: {
     spaces: { spaceId: string; level: string; roles: string[] }[];
     organizations: { organizationId: string; roles: string[] }[];

--- a/lib/src/dto/user/notification.event.payload.user.email.change.new.address.ts
+++ b/lib/src/dto/user/notification.event.payload.user.email.change.new.address.ts
@@ -4,7 +4,7 @@
 export interface NotificationEventPayloadUserEmailChangeNewAddress {
   recipientEmail: string;
   commitTimestampISO8601: string;
-  initiatorRole: "self" | "platform_admin";
+  initiatorRole: 'self' | 'platform_admin';
   newEmailFull: string;
   loginUrl: string;
 }

--- a/lib/src/dto/user/notification.event.payload.user.email.change.security.signal.ts
+++ b/lib/src/dto/user/notification.event.payload.user.email.change.security.signal.ts
@@ -4,6 +4,6 @@
 export interface NotificationEventPayloadUserEmailChangeSecuritySignal {
   recipientEmail: string;
   commitTimestampISO8601: string;
-  initiatorRole: "self" | "platform_admin";
+  initiatorRole: 'self' | 'platform_admin';
   newEmailMasked: string;
 }

--- a/lib/src/dto/user/notification.event.payload.user.email.change.space.admin.ts
+++ b/lib/src/dto/user/notification.event.payload.user.email.change.space.admin.ts
@@ -1,17 +1,16 @@
-import { NotificationEventPayloadSpace } from "../space/notification.event.payload.space";
+import { NotificationEventPayloadSpace } from '../space/notification.event.payload.space';
 
 // Event USER_EMAIL_CHANGE_SPACE_ADMIN_NOTIFICATION — published per qualifying
 // space via the server's buildBaseEventPayload. Extends
 // NotificationEventPayloadSpace, so it carries the full BaseEventPayload
 // envelope (including a server-resolved `recipients` array) plus the single
 // `space` the event concerns.
-export interface NotificationEventPayloadUserEmailChangeSpaceAdmin
-  extends NotificationEventPayloadSpace {
+export interface NotificationEventPayloadUserEmailChangeSpaceAdmin extends NotificationEventPayloadSpace {
   subjectProfileSummary: { id: string; displayName: string };
   oldEmail: string;
   newEmail: string;
   initiatorProfileSummary?: { id: string; displayName: string };
-  initiatorRole: "self" | "platform_admin";
+  initiatorRole: 'self' | 'platform_admin';
   commitTimestampISO8601: string;
-  triggerOutcome: "COMMITTED" | "DRIFT_DETECTED";
+  triggerOutcome: 'COMMITTED' | 'DRIFT_DETECTED';
 }

--- a/lib/src/dto/user/notification.event.payload.user.message.direct.ts
+++ b/lib/src/dto/user/notification.event.payload.user.message.direct.ts
@@ -1,4 +1,4 @@
-import { NotificationEventPayloadUser } from "./notification.event.payload.user";
+import { NotificationEventPayloadUser } from './notification.event.payload.user';
 
 export interface NotificationEventPayloadUserMessageDirect extends NotificationEventPayloadUser {
   message: string;

--- a/lib/src/dto/user/notification.event.payload.user.ts
+++ b/lib/src/dto/user/notification.event.payload.user.ts
@@ -1,7 +1,6 @@
-import { BaseEventPayload } from "../base.event.payload";
-import { UserPayload } from "../user.payload";
+import { BaseEventPayload } from '../base.event.payload';
+import { UserPayload } from '../user.payload';
 
-export interface NotificationEventPayloadUser
-  extends BaseEventPayload {
+export interface NotificationEventPayloadUser extends BaseEventPayload {
   user: UserPayload;
 }

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,2 +1,2 @@
 export * from './dto';
-export * from './common/enums/role.change.type'
+export * from './common/enums/role.change.type';

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["es2019", "esnext.asynciterable", "ES2020.Promise"],
     "sourceMap": true,
     "rootDir": "./src",
@@ -9,7 +9,7 @@
     "declaration": true,
     "removeComments": true,
     "strict": true,
-    "baseUrl": ".",
+    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -17,9 +17,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "paths": {
-      "@src/*": ["src/*"],
-      "@common/*": ["src/common/*"],
+      "@src/*": ["./src/*"],
+      "@common/*": ["./src/common/*"],
     }
   },
   "exclude": ["./node_modules"],

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -50,6 +50,7 @@
         "@types/yaml": "^1.9.7",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
+        "@typescript/native": "npm:typescript@7.0.2",
         "cd": "^0.3.3",
         "coveralls": "^3.1.1",
         "dotenv": "^17.2.1",
@@ -64,7 +65,7 @@
         "rimraf": "^6.0.1",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
-        "typescript": "~5.9.0"
+        "typescript": "npm:@typescript/typescript6@^6.0.2"
       },
       "engines": {
         "node": ">=22.16.0",
@@ -6064,6 +6065,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/@nestjs/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@nestjs/common": {
       "version": "11.1.27",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.27.tgz",
@@ -8044,6 +8059,397 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -20714,17 +21120,17 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/typical": {
@@ -26018,6 +26424,12 @@
             "minimist": "^1.2.6",
             "strip-bom": "^3.0.0"
           }
+        },
+        "typescript": {
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+          "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+          "dev": true
         }
       }
     },
@@ -27330,6 +27742,180 @@
           "dev": true
         }
       }
+    },
+    "@typescript/native": {
+      "version": "npm:typescript@7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "requires": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "@typescript/old": {
+      "version": "npm:typescript@6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true
+    },
+    "@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "dev": true,
+      "optional": true
     },
     "@ungap/structured-clone": {
       "version": "1.3.0",
@@ -35764,10 +36350,13 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "version": "npm:@typescript/typescript6@6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
+      "dev": true,
+      "requires": {
+        "@typescript/old": "npm:typescript@^6"
+      }
     },
     "typical": {
       "version": "7.3.0",

--- a/service/package.json
+++ b/service/package.json
@@ -22,9 +22,10 @@
     "start:debug": "nest start --debug=0.0.0.0:9230 --watch",
     "start:prod": "node dist/main",
     "start:services": "docker-compose -f quickstart-mailslurper.yml up --build --force-recreate",
-    "lint": "tsc --noEmit && eslint src/**/*.ts{,x}",
-    "lint:prod": "tsc --noEmit && cross-env NODE_ENV=production eslint src/**/*.ts{,x}",
-    "lint:fix": "tsc --noEmit && eslint src/**/*.ts{,x} --fix",
+    "lint": "npm run typecheck:native && eslint src/**/*.ts{,x}",
+    "lint:prod": "npm run typecheck:native && cross-env NODE_ENV=production eslint src/**/*.ts{,x}",
+    "lint:fix": "npm run typecheck:native && eslint src/**/*.ts{,x} --fix",
+    "typecheck:native": "tsc -p tsconfig.json --noEmit",
     "test": "jest --config=./test/config/jest.config.js",
     "test:dev": "jest --config=./test/config/jest.config.js --no-cache --coverage=true --detectOpenHandles --runInBand --logHeapUsage",
     "test:watch": "jest --watch",
@@ -77,6 +78,7 @@
     "@types/yaml": "^1.9.7",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
+    "@typescript/native": "npm:typescript@7.0.2",
     "cd": "^0.3.3",
     "coveralls": "^3.1.1",
     "dotenv": "^17.2.1",
@@ -91,7 +93,7 @@
     "rimraf": "^6.0.1",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
-    "typescript": "~5.9.0"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "_moduleAliases": {
     "@src": "./dist"

--- a/service/tsconfig.build.json
+++ b/service/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/service/tsconfig.json
+++ b/service/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["es2019", "esnext.asynciterable", "ES2020.Promise"],
     "sourceMap": true,
     "outDir": "./dist",
     "removeComments": true,
     "strict": true,
-    "baseUrl": "./",
+    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -15,12 +15,13 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "types": ["node", "jest"],
     "paths": {
-      "@src/*": ["src/*"],
-      "@test/*": ["test/*"],
-      "@config/*": ["src/config/*"],
-      "@common/*": ["src/common/*"],
-      "@core/*": ["src/core/*"]
+      "@src/*": ["./src/*"],
+      "@test/*": ["./test/*"],
+      "@config/*": ["./src/config/*"],
+      "@common/*": ["./src/common/*"],
+      "@core/*": ["./src/core/*"]
     }
   },
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
## TypeScript 7 upgrade — notifications slice (workspace#019-typescript-7-upgrade)

npm dual-install across lib/ + service/; lib emit held on tsc6 (js6) per the clean-parity gate matrix; added the missing lib eslint flat-config + CI lint-lib job.

Part of the cross-repo TypeScript 7 (native `tsgo`) upgrade. This repo builds, typechecks (native), lints, and passes its test gates on the dual-compiler layout. See the workspace spec for the fleet-wide playbook and rationale.

---
### Forge evidence digest — `workspace#019-typescript-7-upgrade`
- **Spec / plan / tasks**: `agents-hq/specs/019-typescript-7-upgrade/` (spec.md, plan.md, research/tsgo-playbook.md, per-repo tasks). Board story: alkem-io/alkemio#1799.
- **Architecture**: Fable chief synthesizing a 2-seat Opus council (simplifier seat failed structured output — recorded). Operator dissent on the mandatory-tsgo-floor overruled by operator intake ruling, mechanized as risk R-3.
- **Live verification**: PASS — gql-live 588/588, test-suites configuration suite green, US2 acceptance walk (health, unauth metadata, real admin login, home dashboard on the TS7 bundle) all green; 11/11 risk-register entries mitigated. Durable spec persisted: `test-suites .../ts7-platform-smoke.spec.ts`.
- **Review**: Opus panel × 4 dimensions (correctness, spec-compliance, quality, SOC 2/ISO 27001 security), two-lens adversarial verify. 4 confirmed findings across the feature: 3 fixed (notifications emit ×2, ecosystem-analytics supply-chain scoping), 1 declined (client-web `build:dev --mode` — mandated by plan.md for the acceptance walk).
- **Security**: the run's `security-hold` was triggered **only by pre-existing findings on `develop`**, none introduced by this toolchain change — filed for their owners: cds gateway-header auth (collaborative-document-service#104), organisation static-credential gate (organisation#120), ecosystem-analytics image-proxy SSRF (ecosystem-analytics#115, HIGH) + committed AES key (ecosystem-analytics#116). Operator accepted shipping the clean TS7 change alongside this tracked debt; the HIGH SSRF is getting a separate hotfix PR.
- **Compiler model**: TS 7 native (`tsgo`) as the typecheck gate; the JS-API line (`@typescript/typescript6` 6.0.2, aliased) remains ship-authoritative for emit/test/lint until the TS 7.1 Compiler API lands. Native typecheck speedups measured 7.7–8.5×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
