### PR TITLE
fix(templates): reword "your post" → "the post" in comment notifications

### DIFF
--- a/service/src/email-templates/space.collaboration.callout.comment.js
+++ b/service/src/email-templates/space.collaboration.callout.comment.js
@@ -4,17 +4,17 @@ var templates = require('./alkemio.template.blocks');
 module.exports = () => ({
   name: 'space.collaboration.callout.comment',
   title:
-    '{{space.displayName}} - New comment received on your {{callout.type}}: "{{callout.displayName}}"',
+    '{{space.displayName}} - New comment received on the {{callout.type}}: "{{callout.displayName}}"',
   version: 1,
   channels: {
     email: {
       to: '{{recipient.email}}',
       subject:
-        '{{space.displayName}} - New comment received on your {{callout.type}} "{{callout.displayName}}" by {{createdBy.firstName}}, have a look!',
+        '{{space.displayName}} - New comment received on the {{callout.type}} "{{callout.displayName}}" by {{createdBy.firstName}}, have a look!',
       html: `{% extends "src/email-templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br><br>
 
-        <b>{{createdBy.firstName}}</b> commented on your {{callout.type}} titled: <a style="color:#1d384a; text-decoration: none;" href={{callout.url}}>{{callout.displayName}}</a>.
+        <b>{{createdBy.firstName}}</b> commented on the {{callout.type}} titled: <a style="color:#1d384a; text-decoration: none;" href={{callout.url}}>{{callout.displayName}}</a>.
         <br><br>
         <a class="action-button" href="{{callout.url}}">HAVE A LOOK!</a><br><br>
         {% endblock %}

--- a/service/src/email-templates/space.collaboration.callout.post.contribution.comment.js
+++ b/service/src/email-templates/space.collaboration.callout.post.contribution.comment.js
@@ -4,17 +4,17 @@ var templates = require('./alkemio.template.blocks');
 module.exports = () => ({
   name: 'space.collaboration.callout.post.contribution.comment',
   title:
-    '{{space.displayName}} - New comment received on your Post: "{{post.displayName}}"',
+    '{{space.displayName}} - New comment received on the Post: "{{post.displayName}}"',
   version: 1,
   channels: {
     email: {
       to: '{{recipient.email}}',
       subject:
-        '{{space.displayName}} - New comment received on your Post "{{post.displayName}}", have a look!',
+        '{{space.displayName}} - New comment received on the Post "{{post.displayName}}", have a look!',
       html: `{% extends "src/email-templates/_layouts/email-transactional.html" %}
         {% block content %}Hi {{recipient.firstName}},<br><br>
 
-          <b>{{createdBy.firstName}}</b> commented on your post titled: <a style="color:#1d384a; text-decoration: none;" href={{post.url}}>{{post.displayName}}</a>.
+          <b>{{createdBy.firstName}}</b> commented on the post titled: <a style="color:#1d384a; text-decoration: none;" href={{post.url}}>{{post.displayName}}</a>.
           <br><br>
           <a class="action-button" href="{{post.url}}">HAVE A LOOK!</a><br><br>
 


### PR DESCRIPTION
## Summary

Post-comment notification emails read "your post" to every recipient, but the `space.collaboration.callout.post.contribution.comment` notification is sent to everyone who should be notified of a new comment on a post — not just the post author. Most recipients therefore read "your post" about a post they never created.

This reworks the copy to neutral "the Post" / "the post" wording, matching what the reporter asked for.

## Root cause

The template addressed the reader as the post owner, but the recipient set is all notified users, not the author. Wording, not logic, was wrong.

## Strings changed

`service/src/email-templates/space.collaboration.callout.post.contribution.comment.js`
- **title** — `... New comment received on your Post: "{{post.displayName}}"` → `... New comment received on the Post: "{{post.displayName}}"`
- **subject** — `... New comment received on your Post "{{post.displayName}}", have a look!` → `... New comment received on the Post "{{post.displayName}}", have a look!`
- **body** — `{{createdBy.firstName}} commented on your post titled: ...` → `{{createdBy.firstName}} commented on the post titled: ...`

## Sibling-template check

The story called out two siblings:

- **`space.collaboration.callout.comment.js`** — had the **same** recipient/possessive mismatch (`your {{callout.type}}` in title, subject, and body, sent to all notified recipients). Fixed consistently to `the {{callout.type}}`:
  - title — `... on your {{callout.type}}: "..."` → `... on the {{callout.type}}: "..."`
  - subject — `... on your {{callout.type}} "..." by {{createdBy.firstName}}...` → `... on the {{callout.type}} "..." by {{createdBy.firstName}}...`
  - body — `commented on your {{callout.type}} titled: ...` → `commented on the {{callout.type}} titled: ...`
- **`space.community.calendar.event.comment.js`** — reads fine. It uses neutral wording ("`{{commentor.name}}` commented on `{{calendarEvent.title}}` in the `{{space.displayName}}` calendar") with no owner-addressed possessive. No change.

## Exit gates

- Tests — `npm test`: 10 suites, **222 passed**.
- Build — `npm run build` (`nest build`): clean.
- Typecheck — `tsc -p tsconfig.json --noEmit` (the `typecheck:native` half of `npm run lint`): clean. The subsequent `eslint src/**/*.ts{,x}` step errors on a pre-existing script glob issue (`No files matching the pattern "src/**/*.tsx"` — the repo has no `.tsx` files), unrelated to this change; only `.js` template files were touched, which are outside the TS eslint project by design.

Closes #548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated collaboration email wording to use clearer, more neutral phrasing for callouts and post references.
  * Refined spacing/formatting in transactional post comment email messages for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->