### PR TITLE
Fix escaped Email Subject

### DIFF
--- a/service/src/services/notifme/notification.templates.builder.spec.ts
+++ b/service/src/services/notifme/notification.templates.builder.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks';
+import { NotificationTemplateBuilder } from './notification.templates.builder';
+import { BaseEmailPayload } from '@src/services/notification/email-template-payload';
+
+describe('NotificationTemplateBuilder', () => {
+  let builder: NotificationTemplateBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NotificationTemplateBuilder, MockWinstonProvider],
+    }).compile();
+
+    builder = module.get(NotificationTemplateBuilder);
+  });
+
+  // Payload shaped for user.space.community.joined — space.displayName carries an
+  // ampersand, which must survive verbatim in the plain-text subject/title.
+  const payloadWithAmpersand = {
+    recipient: {
+      firstName: 'Al',
+      email: 'al@example.com',
+    },
+    space: {
+      displayName: 'This & That',
+      url: 'https://alkemio.test/spaces/this-and-that',
+    },
+  } as unknown as BaseEmailPayload;
+
+  it('does not HTML-escape the email subject (plain-text field)', async () => {
+    const result = await builder.buildTemplate(
+      'user.space.community.joined',
+      payloadWithAmpersand
+    );
+
+    expect(result?.channels?.email?.subject).toBe(
+      'This & That - Welcome to the Community!'
+    );
+  });
+
+  it('does not HTML-escape the notification title (plain-text field)', async () => {
+    const result = await builder.buildTemplate(
+      'user.space.community.joined',
+      payloadWithAmpersand
+    );
+
+    expect(result?.title).toBe('This & That - You have joined this community');
+  });
+
+  it('still HTML-escapes display names in the email body (injection safety)', async () => {
+    const result = await builder.buildTemplate(
+      'user.space.community.joined',
+      payloadWithAmpersand
+    );
+
+    expect(result?.channels?.email?.html).toContain('This &amp; That');
+    expect(result?.channels?.email?.html).not.toContain('This & That');
+  });
+
+  it('returns undefined for an unknown template', async () => {
+    const result = await builder.buildTemplate(
+      'does.not.exist',
+      payloadWithAmpersand
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/service/src/services/notifme/notification.templates.builder.spec.ts
+++ b/service/src/services/notifme/notification.templates.builder.spec.ts
@@ -14,15 +14,18 @@ describe('NotificationTemplateBuilder', () => {
     builder = module.get(NotificationTemplateBuilder);
   });
 
-  // Payload shaped for user.space.community.joined — space.displayName carries an
-  // ampersand, which must survive verbatim in the plain-text subject/title.
-  const payloadWithAmpersand = {
+  // Payload shaped for user.space.community.joined — space.displayName carries
+  // every HTML-escapable character, which must survive verbatim in the
+  // plain-text subject/title.
+  const DISPLAY_NAME = 'A & B < C > D \'E" F';
+  const ESCAPED_DISPLAY_NAME = 'A &amp; B &lt; C &gt; D &#39;E&quot; F';
+  const payloadWithEntities = {
     recipient: {
       firstName: 'Al',
       email: 'al@example.com',
     },
     space: {
-      displayName: 'This & That',
+      displayName: DISPLAY_NAME,
       url: 'https://alkemio.test/spaces/this-and-that',
     },
   } as unknown as BaseEmailPayload;
@@ -30,37 +33,48 @@ describe('NotificationTemplateBuilder', () => {
   it('does not HTML-escape the email subject (plain-text field)', async () => {
     const result = await builder.buildTemplate(
       'user.space.community.joined',
-      payloadWithAmpersand
+      payloadWithEntities
     );
 
-    expect(result?.channels?.email?.subject).toBe(
-      'This & That - Welcome to the Community!'
+    expect(result?.channels?.email?.subject).toContain(DISPLAY_NAME);
+    expect(result?.channels?.email?.subject).not.toContain(
+      ESCAPED_DISPLAY_NAME
     );
   });
 
   it('does not HTML-escape the notification title (plain-text field)', async () => {
     const result = await builder.buildTemplate(
       'user.space.community.joined',
-      payloadWithAmpersand
+      payloadWithEntities
     );
 
-    expect(result?.title).toBe('This & That - You have joined this community');
+    expect(result?.title).toContain(DISPLAY_NAME);
+    expect(result?.title).not.toContain(ESCAPED_DISPLAY_NAME);
   });
 
   it('still HTML-escapes display names in the email body (injection safety)', async () => {
     const result = await builder.buildTemplate(
       'user.space.community.joined',
-      payloadWithAmpersand
+      payloadWithEntities
     );
 
-    expect(result?.channels?.email?.html).toContain('This &amp; That');
-    expect(result?.channels?.email?.html).not.toContain('This & That');
+    expect(result?.channels?.email?.html).toContain(ESCAPED_DISPLAY_NAME);
+    expect(result?.channels?.email?.html).not.toContain(DISPLAY_NAME);
   });
 
   it('returns undefined for an unknown template', async () => {
     const result = await builder.buildTemplate(
       'does.not.exist',
-      payloadWithAmpersand
+      payloadWithEntities
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects template names that traverse outside the templates folder', async () => {
+    const result = await builder.buildTemplate(
+      '../../config/some-secret',
+      payloadWithEntities
     );
 
     expect(result).toBeUndefined();

--- a/service/src/services/notifme/notification.templates.builder.ts
+++ b/service/src/services/notifme/notification.templates.builder.ts
@@ -1,12 +1,24 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+import path from 'path';
 import { LoggerService } from '@nestjs/common';
 import { Inject } from '@nestjs/common';
 import { Injectable } from '@nestjs/common';
 import { LogContext } from '@common/enums';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { renderString } from 'nunjucks';
+import { Environment, renderString } from 'nunjucks';
 import { NotificationTemplateType } from '@src/types/notification.template.type';
 import { BaseEmailPayload } from '@src/services/notification/email-template-payload';
+
+const TEMPLATES_FOLDER = './src/email-templates';
+const TEMPLATE_LANG = 'en-US';
+
+// notifme-template renders every string field (to, title, subject, html) through
+// one renderer. The default nunjucks renderer autoescapes, which is required for
+// the HTML body (injection safety) but wrong for the plain-text fields: a mail
+// client shows the subject/title literally, so "A & B" leaks as "A &amp; B".
+// We keep autoescaping for html and re-render only the plain-text fields from the
+// raw template through this non-escaping environment.
+const plainTextEnv = new Environment(undefined, { autoescape: false });
 
 @Injectable()
 export class NotificationTemplateBuilder {
@@ -20,8 +32,13 @@ export class NotificationTemplateBuilder {
   ): Promise<NotificationTemplateType | undefined> {
     try {
       const getRenderer = require('notifme-template');
-      const render = getRenderer(renderString, './src/email-templates');
-      const result = await render(template, templatePayload, 'en-US');
+      const render = getRenderer(renderString, TEMPLATES_FOLDER);
+      const result: NotificationTemplateType = await render(
+        template,
+        templatePayload,
+        TEMPLATE_LANG
+      );
+      this.renderPlainTextFields(template, templatePayload, result);
       return result;
     } catch (error: any) {
       this.logger.error(
@@ -31,5 +48,33 @@ export class NotificationTemplateBuilder {
     }
 
     return undefined;
+  }
+
+  // Overwrite the plain-text fields (title, email subject) with a non-autoescaped
+  // render of the raw template, so HTML entities in display names are not leaked.
+  private renderPlainTextFields(
+    template: string,
+    templatePayload: BaseEmailPayload,
+    result: NotificationTemplateType | undefined
+  ): void {
+    if (!result) {
+      return;
+    }
+    const getRawTemplate = require(path.resolve(TEMPLATES_FOLDER, template));
+    const rawTemplate = getRawTemplate(TEMPLATE_LANG);
+
+    if (rawTemplate?.title != null) {
+      result.title = plainTextEnv.renderString(
+        rawTemplate.title,
+        templatePayload
+      );
+    }
+    const rawSubject = rawTemplate?.channels?.email?.subject;
+    if (rawSubject != null && result.channels?.email) {
+      result.channels.email.subject = plainTextEnv.renderString(
+        rawSubject,
+        templatePayload
+      );
+    }
   }
 }

--- a/service/src/services/notifme/notification.templates.builder.ts
+++ b/service/src/services/notifme/notification.templates.builder.ts
@@ -17,23 +17,36 @@ const TEMPLATE_LANG = 'en-US';
 // the HTML body (injection safety) but wrong for the plain-text fields: a mail
 // client shows the subject/title literally, so "A & B" leaks as "A &amp; B".
 // We keep autoescaping for html and re-render only the plain-text fields from the
-// raw template through this non-escaping environment.
+// raw template through this non-escaping environment. Subject/title are single
+// lines with only {{ }} interpolation — no {% extends/include %}, which would
+// need a loader this environment does not have.
 const plainTextEnv = new Environment(undefined, { autoescape: false });
 
 @Injectable()
 export class NotificationTemplateBuilder {
+  // notifme-template's renderer is initialised once: it closes over the folder
+  // and reuses its internal (module-level) template cache across calls.
+  private readonly render: (
+    template: string,
+    data: BaseEmailPayload,
+    lang: string
+  ) => Promise<NotificationTemplateType>;
+
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private logger: LoggerService
-  ) {}
+  ) {
+    const getRenderer = require('notifme-template');
+    this.render = getRenderer(renderString, TEMPLATES_FOLDER);
+  }
+
   async buildTemplate(
     template: string,
     templatePayload: BaseEmailPayload
   ): Promise<NotificationTemplateType | undefined> {
     try {
-      const getRenderer = require('notifme-template');
-      const render = getRenderer(renderString, TEMPLATES_FOLDER);
-      const result: NotificationTemplateType = await render(
+      this.assertSafeTemplateName(template);
+      const result = await this.render(
         template,
         templatePayload,
         TEMPLATE_LANG
@@ -48,6 +61,15 @@ export class NotificationTemplateBuilder {
     }
 
     return undefined;
+  }
+
+  // Template names come from a fixed internal switch, never user input, but both
+  // the renderer and renderPlainTextFields require() the name off disk — reject
+  // traversal / absolute paths so it can never resolve outside TEMPLATES_FOLDER.
+  private assertSafeTemplateName(template: string): void {
+    if (template.includes('..') || path.isAbsolute(template)) {
+      throw new Error(`Invalid template name: ${template}`);
+    }
   }
 
   // Overwrite the plain-text fields (title, email subject) with a non-autoescaped


### PR DESCRIPTION
### What was wrong
[#1926](https://github.com/alkem-io/alkemio/issues/1926)
A space called `This & That` was shown in the emails sent to users like `This &amp; That`

Email subject/title lines were HTML-escaped. Cause: subjects render through Nunjucks with `autoescape: true` by default. Fix in notification.templates.builder.ts: re-render subject + title from the raw template with a dedicated autoescape: false environment, keeping the HTML body escaped. Covers all 37 templates + a new test.

### What I've verified
- Was it env-specific? Was looking right in MailSlurper, in sandbox/acc/prod we use Scaleway TEM. MailSlurper was just hiding the bug by decoding it in its UI.
- More symbols affected? Yes, these symbols were causing problems `&` `<` `>` `'` `"` all fixed.
- Is this safe? Possible header injection via displayName newlines? No, proved nodemailer folds CRLF to spaces; unchanged by our fix, the symbols are fine for subject line.


### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
