### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -41,7 +41,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v6.0.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v6.0.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-notifications-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       # checkout the repo
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7
 
       - name: "Build and push image"
         uses: azure/docker-login@v2
@@ -40,7 +40,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v6.0.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/26-notifications-deployment-test.yaml

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -45,28 +45,28 @@ jobs:
       contents: read    # Required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.2.0
+        uses: docker/metadata-action@v6
         with:
           # Image name derived from repo name (e.g., alkemio/notifications)
           images: ${{ env.REGISTRY_IMAGE }}
           # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -93,7 +93,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.pair }}
           path: ${{ runner.temp }}/digests/*
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.2.0
+        uses: docker/metadata-action@v6
         env:
           # Also emit OCI annotations targeting the manifest list (index),
           # applied by imagetools create below — labels on the per-arch image
@@ -130,7 +130,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Download digests
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
@@ -149,10 +149,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: service
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: service
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'
@@ -39,10 +39,10 @@ jobs:
         working-directory: lib
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '20.20.2'
           cache: 'npm'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: service
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `Azure/k8s-deploy` | v6.0.0 | v7.0.0 |
| `actions/checkout` | v6 v6.0.3 | v7 |
| `actions/download-artifact` | v8.0.1 | v8 |
| `actions/setup-node` | v6.5.0 | v7 |
| `actions/upload-artifact` | v7.0.1 | v7 |
| `docker/build-push-action` | v7.3.0 | v7 |
| `docker/login-action` | v4.4.0 | v4 |
| `docker/metadata-action` | v6.2.0 | v6 |
| `docker/setup-buildx-action` | v4.2.0 | v4 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
