### PR TITLE
ci(027): move CI off legacy arc-runner-set to hosted runners (workspace#027-arc-v3-runner-migration)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: service

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: service
@@ -33,7 +33,7 @@ jobs:
         run: npm run typecheck:native
 
   lint-lib:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: lib

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: service


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — notifications (wave 2, C-10 audit-gap)

Moves 4 legacy `arc-runner-set` selectors (`ci-build.build`, `ci-test.test`, `ci-lint.{lint,lint-lib}`) to `ubuntu-latest`. These fork-PR jobs ran untrusted code on the **unhardened org-wide set** — an exposure the council audit missed (spec C-10). Zero self-hosted selectors remain.

**Verified:** routing checker PASS; `npm --prefix service ci` clean. ✅ **All-hosted — may merge independently.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, lint, and test automation to run on GitHub-hosted Ubuntu environments.
  * No changes were made to workflow triggers or validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->